### PR TITLE
on-device benchmark harness (v1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ SCRATCH.md
 TODO.md
 .notes/
 .scratch/
+
+# Local-only bench results from Examples/PaletteKitDemo
+benchmark/

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchChart.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchChart.swift
@@ -1,0 +1,77 @@
+import Charts
+import SwiftUI
+
+/// Horizontal stacked-bar chart of decode/sample/quantize times per
+/// BenchCase. Phone-friendly: each case is one row, time on the X axis,
+/// stage breakdown is the stack — answers "where does the time go?" at
+/// a glance, which numbers in a table can't.
+struct BenchChart: View {
+    let summaries: [BenchSummary]
+
+    var body: some View {
+        if summaries.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Stage breakdown")
+                    .font(.headline)
+                Text("mean per-stage ms across post-warmup runs")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+                Chart {
+                    ForEach(stageRows) { row in
+                        BarMark(
+                            x: .value("ms", row.ms),
+                            y: .value("case", row.caseLabel)
+                        )
+                        .foregroundStyle(by: .value("stage", row.stage))
+                    }
+                }
+                .chartForegroundStyleScale([
+                    "decode": Color.blue.opacity(0.85),
+                    "sample": Color.green.opacity(0.85),
+                    "quantize": Color.orange.opacity(0.85),
+                ])
+                .chartLegend(position: .top, alignment: .leading)
+                .chartXAxis {
+                    AxisMarks(format: Decimal.FormatStyle.number.precision(.fractionLength(0)))
+                }
+                .chartYAxis {
+                    AxisMarks { _ in
+                        AxisValueLabel()
+                            .font(.system(size: 10, design: .monospaced))
+                    }
+                }
+                .frame(height: chartHeight)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(.quaternary)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    private var chartHeight: CGFloat {
+        // 24pt per row works well for caption2 monospaced Y labels;
+        // legend and padding need ~70pt fixed.
+        max(120, CGFloat(summaries.count) * 24 + 70)
+    }
+
+    private var stageRows: [StageRow] {
+        summaries.flatMap { s in
+            [
+                StageRow(caseLabel: s.benchCase.compactLabel, stage: "decode", ms: s.decodeMeanMs),
+                StageRow(caseLabel: s.benchCase.compactLabel, stage: "sample", ms: s.sampleMeanMs),
+                StageRow(caseLabel: s.benchCase.compactLabel, stage: "quantize", ms: s.quantizeMeanMs),
+            ]
+        }
+    }
+
+    private struct StageRow: Identifiable {
+        let id = UUID()
+        let caseLabel: String
+        let stage: String
+        let ms: Double
+    }
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchExport.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchExport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PaletteKit
 
 enum BenchExport {
     /// Per-run rows. Useful for plotting the full distribution including
@@ -6,14 +7,22 @@ enum BenchExport {
     static func rawCSV(
         device: DeviceInfo,
         startedAt: Date?,
+        runNote: String,
+        sourceDescription: String,
         samples: [BenchSample]
     ) -> String {
         var lines: [String] = []
+        lines.append("# palettekit_version,\(paletteKitVersion)")
         lines.append("# device,\(device.model)")
+        lines.append("# device_marketing,\(device.marketingName)")
         lines.append("# os,\(device.osVersion)")
         lines.append("# cpu_cores,\(device.processorCount)")
+        lines.append("# source,\(escape(sourceDescription))")
         if let startedAt {
             lines.append("# started_at,\(iso8601(startedAt))")
+        }
+        if !runNote.isEmpty {
+            lines.append("# note,\(escape(runNote))")
         }
         lines.append(
             "case_id,size_px,quantizer,downsample,run_index,is_warmup,total_ms,decode_ms,sample_ms,quantize_ms,engine,palette_count,error"
@@ -47,13 +56,21 @@ enum BenchExport {
     /// the table you read first when comparing runs across devices.
     static func summaryCSV(
         device: DeviceInfo,
+        runNote: String,
+        sourceDescription: String,
         summaries: [BenchSummary]
     ) -> String {
         var lines: [String] = []
+        lines.append("# palettekit_version,\(paletteKitVersion)")
         lines.append("# device,\(device.model)")
+        lines.append("# device_marketing,\(device.marketingName)")
         lines.append("# os,\(device.osVersion)")
+        lines.append("# source,\(escape(sourceDescription))")
+        if !runNote.isEmpty {
+            lines.append("# note,\(escape(runNote))")
+        }
         lines.append(
-            "size_px,quantizer,downsample,runs,total_p50_ms,total_p95_ms,total_min_ms,total_max_ms,quantize_p50_ms,quantize_p95_ms,engine,errors"
+            "size_px,quantizer,downsample,runs,total_p50_ms,total_p95_ms,total_min_ms,total_max_ms,quantize_p50_ms,quantize_p95_ms,decode_mean_ms,sample_mean_ms,quantize_mean_ms,engine,errors"
         )
         for s in summaries {
             let row: [String] = [
@@ -67,6 +84,9 @@ enum BenchExport {
                 msFromMs(s.totalMaxMs),
                 msFromMs(s.quantizeP50ms),
                 msFromMs(s.quantizeP95ms),
+                msFromMs(s.decodeMeanMs),
+                msFromMs(s.sampleMeanMs),
+                msFromMs(s.quantizeMeanMs),
                 escape(s.engineUsed),
                 String(s.errorCount),
             ]

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchExport.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchExport.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+enum BenchExport {
+    /// Per-run rows. Useful for plotting the full distribution including
+    /// warmup so we can see how big the cold-start cost actually is.
+    static func rawCSV(
+        device: DeviceInfo,
+        startedAt: Date?,
+        samples: [BenchSample]
+    ) -> String {
+        var lines: [String] = []
+        lines.append("# device,\(device.model)")
+        lines.append("# os,\(device.osVersion)")
+        lines.append("# cpu_cores,\(device.processorCount)")
+        if let startedAt {
+            lines.append("# started_at,\(iso8601(startedAt))")
+        }
+        lines.append(
+            "case_id,size_px,quantizer,downsample,run_index,is_warmup,total_ms,decode_ms,sample_ms,quantize_ms,engine,palette_count,error"
+        )
+        for sample in samples {
+            let parts = sample.caseId.split(separator: "-")
+            let size = parts.count > 0 ? String(parts[0]) : ""
+            let quantizer = parts.count > 1 ? String(parts[1]) : ""
+            let downsample = parts.count > 2 ? String(parts[2]) : ""
+            let row: [String] = [
+                sample.caseId,
+                size,
+                quantizer,
+                downsample,
+                String(sample.runIndex),
+                sample.isWarmup ? "1" : "0",
+                ms(sample.totalSeconds),
+                ms(sample.decodeSeconds),
+                ms(sample.sampleSeconds),
+                ms(sample.quantizeSeconds),
+                escape(sample.engineUsed),
+                String(sample.paletteCount),
+                escape(sample.errorMessage ?? ""),
+            ]
+            lines.append(row.joined(separator: ","))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// One row per BenchCase with post-warmup p50/p95/min/max. This is
+    /// the table you read first when comparing runs across devices.
+    static func summaryCSV(
+        device: DeviceInfo,
+        summaries: [BenchSummary]
+    ) -> String {
+        var lines: [String] = []
+        lines.append("# device,\(device.model)")
+        lines.append("# os,\(device.osVersion)")
+        lines.append(
+            "size_px,quantizer,downsample,runs,total_p50_ms,total_p95_ms,total_min_ms,total_max_ms,quantize_p50_ms,quantize_p95_ms,engine,errors"
+        )
+        for s in summaries {
+            let row: [String] = [
+                String(s.benchCase.pixelSide),
+                s.benchCase.quantizer.rawValue,
+                s.benchCase.downsample.rawValue,
+                String(s.runCount),
+                msFromMs(s.totalP50ms),
+                msFromMs(s.totalP95ms),
+                msFromMs(s.totalMinMs),
+                msFromMs(s.totalMaxMs),
+                msFromMs(s.quantizeP50ms),
+                msFromMs(s.quantizeP95ms),
+                escape(s.engineUsed),
+                String(s.errorCount),
+            ]
+            lines.append(row.joined(separator: ","))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func writeToTemp(name: String, contents: String) -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        let url = dir.appendingPathComponent(name)
+        try? contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func ms(_ seconds: Double) -> String {
+        String(format: "%.3f", seconds * 1000)
+    }
+
+    private static func msFromMs(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private static func escape(_ s: String) -> String {
+        if s.contains(",") || s.contains("\"") || s.contains("\n") {
+            return "\"" + s.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+        }
+        return s
+    }
+
+    private static func iso8601(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        return formatter.string(from: date)
+    }
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchFixture.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchFixture.swift
@@ -91,4 +91,43 @@ enum BenchFixture {
     private static func clamp01(_ value: Double) -> Double {
         min(max(value, 0), 1)
     }
+
+    /// Center-crops `source` to a square and rescales to `side × side`.
+    /// Used when the bench source is a real photo: the bench grid is
+    /// driven by side length, so all photos go through the same
+    /// "square at size N" normalization regardless of original aspect.
+    /// sRGB / premultipliedLast to match the synthesized fixture so
+    /// quantize work is apples-to-apples across source kinds.
+    static func resizeToSquare(_ source: CGImage, side: Int) -> CGImage {
+        precondition(side > 0)
+        let srcW = source.width
+        let srcH = source.height
+        let cropEdge = min(srcW, srcH)
+        let cropX = (srcW - cropEdge) / 2
+        let cropY = (srcH - cropEdge) / 2
+
+        let cropped = source.cropping(
+            to: CGRect(x: cropX, y: cropY, width: cropEdge, height: cropEdge)
+        ) ?? source
+
+        let bytesPerRow = side * 4
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+            | CGBitmapInfo.byteOrder32Big.rawValue
+
+        guard let context = CGContext(
+            data: nil,
+            width: side,
+            height: side,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            return cropped
+        }
+        context.interpolationQuality = .high
+        context.draw(cropped, in: CGRect(x: 0, y: 0, width: side, height: side))
+        return context.makeImage() ?? cropped
+    }
 }

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchFixture.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchFixture.swift
@@ -1,0 +1,94 @@
+import CoreGraphics
+import Foundation
+
+/// Synthesizes a deterministic photo-ish CGImage at the requested square
+/// size: smooth color gradient + low-frequency noise + a few colored
+/// blobs. The point is to give the quantizer a wide tonal distribution
+/// rather than the trivial 2-axis ramp the unit-test fixture uses, so
+/// MMCQ has real work to do.
+enum BenchFixture {
+    static func makePhotoLike(side: Int) -> CGImage {
+        precondition(side > 0)
+        let bytesPerRow = side * 4
+        var pixels = [UInt8](repeating: 0, count: bytesPerRow * side)
+
+        let blobs: [(cx: Double, cy: Double, r: Double, color: (Double, Double, Double))] = [
+            (0.25, 0.25, 0.18, (0.92, 0.30, 0.25)),
+            (0.75, 0.30, 0.22, (0.20, 0.55, 0.85)),
+            (0.50, 0.70, 0.28, (0.90, 0.78, 0.20)),
+            (0.20, 0.80, 0.16, (0.15, 0.70, 0.40)),
+            (0.85, 0.85, 0.14, (0.55, 0.25, 0.70)),
+        ]
+
+        let dimension = Double(side)
+        for row in 0..<side {
+            for col in 0..<side {
+                let u = Double(col) / dimension
+                let v = Double(row) / dimension
+
+                var red = 0.30 + 0.55 * u
+                var green = 0.40 + 0.45 * v
+                var blue = 0.50 + 0.40 * (1.0 - u)
+
+                for blob in blobs {
+                    let dx = u - blob.cx
+                    let dy = v - blob.cy
+                    let d = (dx * dx + dy * dy).squareRoot()
+                    let weight = max(0, 1 - d / blob.r)
+                    let w2 = weight * weight
+                    red = red * (1 - w2) + blob.color.0 * w2
+                    green = green * (1 - w2) + blob.color.1 * w2
+                    blue = blue * (1 - w2) + blob.color.2 * w2
+                }
+
+                let noise = pseudoNoise(col, row)
+                red = clamp01(red + noise * 0.06)
+                green = clamp01(green + noise * 0.06)
+                blue = clamp01(blue + noise * 0.06)
+
+                let offset = row * bytesPerRow + col * 4
+                pixels[offset] = UInt8(red * 255)
+                pixels[offset + 1] = UInt8(green * 255)
+                pixels[offset + 2] = UInt8(blue * 255)
+                pixels[offset + 3] = 255
+            }
+        }
+
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+            | CGBitmapInfo.byteOrder32Big.rawValue
+        let provider = CGDataProvider(data: Data(pixels) as CFData)!
+        return CGImage(
+            width: side,
+            height: side,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        )!
+    }
+
+    @inline(__always)
+    private static func pseudoNoise(_ x: Int, _ y: Int) -> Double {
+        // Cheap deterministic hash to a [-1, 1] value. Not cryptographic,
+        // not Perlin — only meant to break up flat banding so each pixel
+        // sees a slightly different RGB value, which keeps the histogram
+        // populated with realistic spread.
+        var h = UInt64(bitPattern: Int64(x &* 374761393 + y &* 668265263))
+        h ^= h >> 13
+        h = h &* 1274126177
+        h ^= h >> 16
+        let normalized = Double(h & 0xFFFF) / 65535.0
+        return normalized * 2 - 1
+    }
+
+    @inline(__always)
+    private static func clamp01(_ value: Double) -> Double {
+        min(max(value, 0), 1)
+    }
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchInfo.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchInfo.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+struct BenchInfo {
+    let title: String
+    let description: String
+    let guidance: String
+
+    static let autoDownsample = BenchInfo(
+        title: "Auto downsample",
+        description: """
+PaletteKit's default behavior. Inputs above 1,000,000 pixels (≈1024²) \
+are scaled down before quantization, so latency stays roughly flat \
+regardless of input size. This is what your end users actually experience \
+when calling palette(from:) without overrides.
+""",
+        guidance: "Enable to measure real-world user-facing latency."
+    )
+
+    static let rawDownsample = BenchInfo(
+        title: "Raw (no downsample)",
+        description: """
+Disables auto-downsample so the full input pixel buffer is fed straight \
+to the quantizer. Reveals the true cost of the CPU vs Metal histogram \
+path at the actual pixel count — useful for validating the auto-gating \
+threshold or comparing quantizer engines on raw work.
+""",
+        guidance: "Not a real-world UX scenario. Enable when comparing engines or stress-testing."
+    )
+
+    static let include8K = BenchInfo(
+        title: "Include 8192²",
+        description: """
+Adds an 8K (67M pixel) row to every quantizer × downsample combination. \
+Each run holds ≈256 MB of raw pixel memory before downsampling.
+""",
+        guidance: "Recommended only on devices with 8 GB+ RAM (iPhone 15 Pro and up, iPad M-series)."
+    )
+
+    static let warmupRuns = BenchInfo(
+        title: "Warmup runs",
+        description: """
+Runs to discard before measurement begins. The first call to a Metal \
+quantizer compiles the shader and builds pipeline state — that one-time \
+cost would pollute steady-state numbers if measured. CPU has smaller \
+cold-cache effects on its first call too.
+""",
+        guidance: "1 is right for most cases. Set to 0 to include cold-start cost in samples."
+    )
+
+    static let measuredRuns = BenchInfo(
+        title: "Measured runs",
+        description: """
+Runs collected after warmup, used to compute p50, p95, min, and max. \
+Five is enough for a stable median; more gives smoother percentiles but \
+exposes thermal throttling on long sessions.
+""",
+        guidance: "3 = quick check, 5 = normal, 10 = exposes thermal effects."
+    )
+
+    static let source = BenchInfo(
+        title: "Source image",
+        description: """
+What gets fed to the quantizer at each grid size.
+
+Synthesized — a deterministic image (gradient + 5 colored blobs + \
+per-pixel noise) generated in memory. Same content on every run, on \
+every device. No file decode is exercised.
+
+Photo — a photo you pick from your library. PaletteKit center-crops \
+it to a square and rescales (high-quality interpolation) to each grid \
+size. Lets you measure the quantizer on real-world color distributions.
+""",
+        guidance: "Synthesized = reproducible cross-device comparisons. Photo = realistic content sanity check; numbers will not be directly comparable to synthesized runs."
+    )
+
+    static let runNote = BenchInfo(
+        title: "Run note",
+        description: """
+Free-text label attached to the run. It shows up in the CSV header so \
+that exports from the same device under different conditions stay \
+distinguishable when you collect them later.
+""",
+        guidance: "Examples: \"quiet, room temp\", \"after a 10-min game\", \"low-power mode on\"."
+    )
+}
+
+/// Tappable info chip used next to a Configuration row label.
+/// Shows the explanation as a popover (compact-adapted on iPhone).
+struct InfoButton: View {
+    let info: BenchInfo
+    @State private var presented = false
+
+    var body: some View {
+        Button {
+            presented = true
+        } label: {
+            Image(systemName: "info.circle")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $presented) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(info.title)
+                    .font(.headline)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(info.description)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Divider()
+                Text(info.guidance)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(16)
+            .frame(width: 300, alignment: .leading)
+            .presentationCompactAdaptation(.popover)
+        }
+    }
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchModels.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchModels.swift
@@ -4,6 +4,7 @@ import PaletteKit
 /// One benchmark cell: a size × quantizer × downsample-mode combination.
 struct BenchCase: Identifiable, Hashable {
     enum QuantizerKind: String, CaseIterable, Hashable {
+        case auto
         case cpu
         case metal
     }
@@ -27,13 +28,26 @@ struct BenchCase: Identifiable, Hashable {
     }
 
     func paletteOptions(colorCount: Int = 10) -> ExtractionOptions {
-        ExtractionOptions(
+        let q: QuantizerSelection
+        switch quantizer {
+        case .auto: q = .auto
+        case .cpu: q = .cpu
+        case .metal: q = .metal
+        }
+        return ExtractionOptions(
             colorCount: colorCount,
             colorSpace: .oklch,
             downsample: downsample == .auto ? .default : .disabled,
-            quantizer: quantizer == .cpu ? .cpu : .metal,
+            quantizer: q,
             collectTimings: true
         )
+    }
+
+    /// Short label used as a chart Y-axis label or for compact summary
+    /// rows. Goal: ~16 characters, monospace-friendly.
+    var compactLabel: String {
+        let dsTag = downsample == .auto ? "ds" : "raw"
+        return "\(pixelSide)² · \(quantizer.rawValue) · \(dsTag)"
     }
 }
 
@@ -64,6 +78,12 @@ struct BenchSummary: Identifiable, Hashable {
     let totalMaxMs: Double
     let quantizeP50ms: Double
     let quantizeP95ms: Double
+    /// Mean per-stage breakdown across the post-warmup runs in ms.
+    /// Used for the stacked bar chart so you can see decode/sample
+    /// dominance over quantize at scale.
+    let decodeMeanMs: Double
+    let sampleMeanMs: Double
+    let quantizeMeanMs: Double
     let engineUsed: String
     let errorCount: Int
 }
@@ -81,6 +101,13 @@ struct DeviceInfo: Hashable {
             processorCount: pi.activeProcessorCount
         )
     }
+
+    /// Maps the raw hardware identifier ("iPhone16,1") to a marketing
+    /// name ("iPhone 15 Pro"). Falls back to the identifier when the
+    /// model is unknown so exports stay disambiguated.
+    var marketingName: String {
+        DeviceModel.marketingName(for: model)
+    }
 }
 
 /// Returns hardware identifier like "iPhone15,3" so different chip
@@ -94,4 +121,101 @@ private func deviceModelIdentifier() -> String {
         return partial + String(UnicodeScalar(UInt8(value)))
     }
     return identifier.isEmpty ? "unknown" : identifier
+}
+
+enum DeviceModel {
+    static func marketingName(for identifier: String) -> String {
+        if let mapped = lookup[identifier] { return mapped }
+        if identifier == "arm64" || identifier == "x86_64" {
+            return "Simulator (\(identifier))"
+        }
+        return identifier
+    }
+
+    /// iOS-only library, so the table covers iPhone (XS+) and recent
+    /// iPad models; older entries are pruned because PaletteKit
+    /// requires iOS 17+. New devices can be added as they ship.
+    private static let lookup: [String: String] = [
+        // iPhone XS / XR
+        "iPhone11,2": "iPhone XS",
+        "iPhone11,4": "iPhone XS Max",
+        "iPhone11,6": "iPhone XS Max",
+        "iPhone11,8": "iPhone XR",
+
+        // iPhone 11
+        "iPhone12,1": "iPhone 11",
+        "iPhone12,3": "iPhone 11 Pro",
+        "iPhone12,5": "iPhone 11 Pro Max",
+        "iPhone12,8": "iPhone SE (2nd gen)",
+
+        // iPhone 12
+        "iPhone13,1": "iPhone 12 mini",
+        "iPhone13,2": "iPhone 12",
+        "iPhone13,3": "iPhone 12 Pro",
+        "iPhone13,4": "iPhone 12 Pro Max",
+
+        // iPhone 13
+        "iPhone14,2": "iPhone 13 Pro",
+        "iPhone14,3": "iPhone 13 Pro Max",
+        "iPhone14,4": "iPhone 13 mini",
+        "iPhone14,5": "iPhone 13",
+        "iPhone14,6": "iPhone SE (3rd gen)",
+
+        // iPhone 14
+        "iPhone14,7": "iPhone 14",
+        "iPhone14,8": "iPhone 14 Plus",
+        "iPhone15,2": "iPhone 14 Pro",
+        "iPhone15,3": "iPhone 14 Pro Max",
+
+        // iPhone 15
+        "iPhone15,4": "iPhone 15",
+        "iPhone15,5": "iPhone 15 Plus",
+        "iPhone16,1": "iPhone 15 Pro",
+        "iPhone16,2": "iPhone 15 Pro Max",
+
+        // iPhone 16
+        "iPhone17,1": "iPhone 16 Pro",
+        "iPhone17,2": "iPhone 16 Pro Max",
+        "iPhone17,3": "iPhone 16",
+        "iPhone17,4": "iPhone 16 Plus",
+        "iPhone17,5": "iPhone 16e",
+
+        // iPad mini
+        "iPad14,1": "iPad mini (6th gen)",
+        "iPad14,2": "iPad mini (6th gen)",
+        "iPad16,1": "iPad mini (A17 Pro)",
+        "iPad16,2": "iPad mini (A17 Pro)",
+
+        // iPad Air
+        "iPad13,16": "iPad Air (5th gen)",
+        "iPad13,17": "iPad Air (5th gen)",
+        "iPad14,8": "iPad Air 11\" (M2)",
+        "iPad14,9": "iPad Air 11\" (M2)",
+        "iPad14,10": "iPad Air 13\" (M2)",
+        "iPad14,11": "iPad Air 13\" (M2)",
+
+        // iPad (regular)
+        "iPad12,1": "iPad (9th gen)",
+        "iPad12,2": "iPad (9th gen)",
+        "iPad13,18": "iPad (10th gen)",
+        "iPad13,19": "iPad (10th gen)",
+
+        // iPad Pro
+        "iPad13,4": "iPad Pro 11\" (5th gen, M1)",
+        "iPad13,5": "iPad Pro 11\" (5th gen, M1)",
+        "iPad13,6": "iPad Pro 11\" (5th gen, M1)",
+        "iPad13,7": "iPad Pro 11\" (5th gen, M1)",
+        "iPad13,8": "iPad Pro 12.9\" (5th gen, M1)",
+        "iPad13,9": "iPad Pro 12.9\" (5th gen, M1)",
+        "iPad13,10": "iPad Pro 12.9\" (5th gen, M1)",
+        "iPad13,11": "iPad Pro 12.9\" (5th gen, M1)",
+        "iPad14,3": "iPad Pro 11\" (4th gen, M2)",
+        "iPad14,4": "iPad Pro 11\" (4th gen, M2)",
+        "iPad14,5": "iPad Pro 12.9\" (6th gen, M2)",
+        "iPad14,6": "iPad Pro 12.9\" (6th gen, M2)",
+        "iPad16,3": "iPad Pro 11\" (M4)",
+        "iPad16,4": "iPad Pro 11\" (M4)",
+        "iPad16,5": "iPad Pro 13\" (M4)",
+        "iPad16,6": "iPad Pro 13\" (M4)",
+    ]
 }

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchModels.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchModels.swift
@@ -1,0 +1,97 @@
+import Foundation
+import PaletteKit
+
+/// One benchmark cell: a size × quantizer × downsample-mode combination.
+struct BenchCase: Identifiable, Hashable {
+    enum QuantizerKind: String, CaseIterable, Hashable {
+        case cpu
+        case metal
+    }
+
+    enum DownsampleKind: String, CaseIterable, Hashable {
+        case auto
+        case disabled
+    }
+
+    let pixelSide: Int
+    let quantizer: QuantizerKind
+    let downsample: DownsampleKind
+
+    var id: String { "\(pixelSide)-\(quantizer.rawValue)-\(downsample.rawValue)" }
+
+    var totalPixels: Int { pixelSide * pixelSide }
+
+    var label: String {
+        let dsTag = downsample == .auto ? "auto" : "raw"
+        return "\(pixelSide)² · \(quantizer.rawValue.uppercased()) · \(dsTag)"
+    }
+
+    func paletteOptions(colorCount: Int = 10) -> ExtractionOptions {
+        ExtractionOptions(
+            colorCount: colorCount,
+            colorSpace: .oklch,
+            downsample: downsample == .auto ? .default : .disabled,
+            quantizer: quantizer == .cpu ? .cpu : .metal,
+            collectTimings: true
+        )
+    }
+}
+
+/// One run of one BenchCase. `runIndex == 0` is the warmup run and is
+/// excluded from summary statistics.
+struct BenchSample: Identifiable, Hashable {
+    let id = UUID()
+    let caseId: String
+    let runIndex: Int
+    let isWarmup: Bool
+    let totalSeconds: Double
+    let decodeSeconds: Double
+    let sampleSeconds: Double
+    let quantizeSeconds: Double
+    let engineUsed: String
+    let paletteCount: Int
+    let errorMessage: String?
+}
+
+/// Aggregated stats for one BenchCase (post-warmup runs only).
+struct BenchSummary: Identifiable, Hashable {
+    let id: String
+    let benchCase: BenchCase
+    let runCount: Int
+    let totalP50ms: Double
+    let totalP95ms: Double
+    let totalMinMs: Double
+    let totalMaxMs: Double
+    let quantizeP50ms: Double
+    let quantizeP95ms: Double
+    let engineUsed: String
+    let errorCount: Int
+}
+
+struct DeviceInfo: Hashable {
+    let model: String
+    let osVersion: String
+    let processorCount: Int
+
+    static var current: DeviceInfo {
+        let pi = ProcessInfo.processInfo
+        return DeviceInfo(
+            model: deviceModelIdentifier(),
+            osVersion: pi.operatingSystemVersionString,
+            processorCount: pi.activeProcessorCount
+        )
+    }
+}
+
+/// Returns hardware identifier like "iPhone15,3" so different chip
+/// generations show up clearly in CSV exports.
+private func deviceModelIdentifier() -> String {
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let mirror = Mirror(reflecting: systemInfo.machine)
+    let identifier = mirror.children.reduce("") { partial, element in
+        guard let value = element.value as? Int8, value != 0 else { return partial }
+        return partial + String(UnicodeScalar(UInt8(value)))
+    }
+    return identifier.isEmpty ? "unknown" : identifier
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchRunner.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchRunner.swift
@@ -1,0 +1,215 @@
+import CoreGraphics
+import Foundation
+import PaletteKit
+
+@MainActor
+final class BenchRunner: ObservableObject {
+    struct Configuration: Equatable {
+        var includeAutoDownsample = true
+        var includeRawDownsample = false
+        var include8K = false
+        var warmupRuns = 1
+        var measuredRuns = 5
+    }
+
+    enum Phase: Equatable {
+        case idle
+        case running(currentIndex: Int, total: Int, currentLabel: String)
+        case finished
+        case failed(message: String)
+    }
+
+    @Published private(set) var phase: Phase = .idle
+    @Published private(set) var samples: [BenchSample] = []
+    @Published private(set) var summaries: [BenchSummary] = []
+    @Published private(set) var startedAt: Date?
+
+    private var task: Task<Void, Never>?
+    private let extractor = PaletteExtractor()
+
+    var isRunning: Bool {
+        if case .running = phase { return true }
+        return false
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+
+    func reset() {
+        cancel()
+        samples = []
+        summaries = []
+        phase = .idle
+        startedAt = nil
+    }
+
+    func run(configuration: Configuration) {
+        cancel()
+        let cases = Self.makeCases(configuration: configuration)
+        let totalRuns = cases.count * (configuration.warmupRuns + configuration.measuredRuns)
+        guard totalRuns > 0 else {
+            phase = .failed(message: "No bench cases selected.")
+            return
+        }
+        samples = []
+        summaries = []
+        startedAt = Date()
+        phase = .running(currentIndex: 0, total: totalRuns, currentLabel: cases.first?.label ?? "")
+
+        task = Task { [weak self] in
+            guard let self else { return }
+            await self.execute(cases: cases, configuration: configuration, totalRuns: totalRuns)
+        }
+    }
+
+    private func execute(
+        cases: [BenchCase],
+        configuration: Configuration,
+        totalRuns: Int
+    ) async {
+        var collected: [BenchSample] = []
+        var globalRunIndex = 0
+
+        for benchCase in cases {
+            if Task.isCancelled { break }
+            let image = BenchFixture.makePhotoLike(side: benchCase.pixelSide)
+            let runs = configuration.warmupRuns + configuration.measuredRuns
+            for runIndex in 0..<runs {
+                if Task.isCancelled { break }
+                let isWarmup = runIndex < configuration.warmupRuns
+                let label = "\(benchCase.label)  run \(runIndex + 1)/\(runs)"
+                phase = .running(
+                    currentIndex: globalRunIndex,
+                    total: totalRuns,
+                    currentLabel: label
+                )
+                let sample = await runSingle(
+                    benchCase: benchCase,
+                    image: image,
+                    runIndex: runIndex,
+                    isWarmup: isWarmup
+                )
+                collected.append(sample)
+                samples = collected
+                globalRunIndex += 1
+            }
+        }
+
+        let final = collected
+        samples = final
+        summaries = Self.summarize(samples: final, cases: cases)
+        phase = Task.isCancelled ? .idle : .finished
+        task = nil
+    }
+
+    private func runSingle(
+        benchCase: BenchCase,
+        image: CGImage,
+        runIndex: Int,
+        isWarmup: Bool
+    ) async -> BenchSample {
+        let options = benchCase.paletteOptions()
+        let clock = ContinuousClock()
+        let started = clock.now
+        do {
+            let palette = try await extractor.palette(
+                from: .cgImage(image),
+                options: options
+            )
+            let elapsed = started.duration(to: clock.now)
+            let timings = palette.timings
+            return BenchSample(
+                caseId: benchCase.id,
+                runIndex: runIndex,
+                isWarmup: isWarmup,
+                totalSeconds: durationSeconds(elapsed),
+                decodeSeconds: timings.map { durationSeconds($0.decode) } ?? 0,
+                sampleSeconds: timings.map { durationSeconds($0.sample) } ?? 0,
+                quantizeSeconds: timings.map { durationSeconds($0.quantize) } ?? 0,
+                engineUsed: timings?.quantizerUsed ?? "?",
+                paletteCount: palette.colors.count,
+                errorMessage: nil
+            )
+        } catch {
+            let elapsed = started.duration(to: clock.now)
+            return BenchSample(
+                caseId: benchCase.id,
+                runIndex: runIndex,
+                isWarmup: isWarmup,
+                totalSeconds: durationSeconds(elapsed),
+                decodeSeconds: 0,
+                sampleSeconds: 0,
+                quantizeSeconds: 0,
+                engineUsed: "error",
+                paletteCount: 0,
+                errorMessage: String(describing: error)
+            )
+        }
+    }
+
+    // MARK: - Cases
+
+    static func makeCases(configuration: Configuration) -> [BenchCase] {
+        var sides: [Int] = [256, 512, 1024, 2048, 4096]
+        if configuration.include8K { sides.append(8192) }
+
+        var downsampleModes: [BenchCase.DownsampleKind] = []
+        if configuration.includeAutoDownsample { downsampleModes.append(.auto) }
+        if configuration.includeRawDownsample { downsampleModes.append(.disabled) }
+        guard !downsampleModes.isEmpty else { return [] }
+
+        var cases: [BenchCase] = []
+        for side in sides {
+            for ds in downsampleModes {
+                for q in BenchCase.QuantizerKind.allCases {
+                    cases.append(BenchCase(pixelSide: side, quantizer: q, downsample: ds))
+                }
+            }
+        }
+        return cases
+    }
+
+    // MARK: - Summary
+
+    static func summarize(samples: [BenchSample], cases: [BenchCase]) -> [BenchSummary] {
+        var summaries: [BenchSummary] = []
+        for benchCase in cases {
+            let measured = samples.filter { $0.caseId == benchCase.id && !$0.isWarmup }
+            guard !measured.isEmpty else { continue }
+            let totalsMs = measured.map { $0.totalSeconds * 1000 }
+            let quantizesMs = measured.map { $0.quantizeSeconds * 1000 }
+            let engine = measured.last?.engineUsed ?? "?"
+            let errorCount = measured.filter { $0.errorMessage != nil }.count
+            summaries.append(
+                BenchSummary(
+                    id: benchCase.id,
+                    benchCase: benchCase,
+                    runCount: measured.count,
+                    totalP50ms: percentile(totalsMs, p: 0.50),
+                    totalP95ms: percentile(totalsMs, p: 0.95),
+                    totalMinMs: totalsMs.min() ?? 0,
+                    totalMaxMs: totalsMs.max() ?? 0,
+                    quantizeP50ms: percentile(quantizesMs, p: 0.50),
+                    quantizeP95ms: percentile(quantizesMs, p: 0.95),
+                    engineUsed: engine,
+                    errorCount: errorCount
+                )
+            )
+        }
+        return summaries
+    }
+
+    private static func percentile(_ values: [Double], p: Double) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let rank = max(0, min(sorted.count - 1, Int((Double(sorted.count - 1) * p).rounded())))
+        return sorted[rank]
+    }
+}
+
+private func durationSeconds(_ duration: Duration) -> Double {
+    let components = duration.components
+    return Double(components.seconds) + Double(components.attoseconds) * 1e-18
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchRunner.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchRunner.swift
@@ -5,11 +5,25 @@ import PaletteKit
 @MainActor
 final class BenchRunner: ObservableObject {
     struct Configuration: Equatable {
+        enum SourceKind: String, CaseIterable, Hashable {
+            case synthesized
+            case photo
+        }
+
         var includeAutoDownsample = true
         var includeRawDownsample = false
         var include8K = false
         var warmupRuns = 1
         var measuredRuns = 5
+        /// Optional human-readable note attached to the run — flows into
+        /// the CSV header so cross-device / cross-condition comparisons
+        /// can be tagged ("iPhone 15 Pro / quiet", "after game", etc).
+        var runNote: String = ""
+        /// Source for the input image at each grid size. Synthesized
+        /// generates a deterministic gradient + noise + blobs scene;
+        /// photo expects the caller to provide a CGImage that gets
+        /// center-cropped and resized to each grid side.
+        var sourceKind: SourceKind = .synthesized
     }
 
     enum Phase: Equatable {
@@ -23,6 +37,10 @@ final class BenchRunner: ObservableObject {
     @Published private(set) var samples: [BenchSample] = []
     @Published private(set) var summaries: [BenchSummary] = []
     @Published private(set) var startedAt: Date?
+    @Published private(set) var runNote: String = ""
+    /// Description of the source used (e.g. "synthesized" or
+    /// "photo 4032x3024"). Persisted into CSV headers.
+    @Published private(set) var sourceDescription: String = "synthesized"
 
     private var task: Task<Void, Never>?
     private let extractor = PaletteExtractor()
@@ -30,6 +48,14 @@ final class BenchRunner: ObservableObject {
     var isRunning: Bool {
         if case .running = phase { return true }
         return false
+    }
+
+    var failureCount: Int {
+        samples.filter { !$0.isWarmup && $0.errorMessage != nil }.count
+    }
+
+    var firstFailureMessage: String? {
+        samples.first(where: { $0.errorMessage != nil })?.errorMessage
     }
 
     func cancel() {
@@ -43,10 +69,20 @@ final class BenchRunner: ObservableObject {
         summaries = []
         phase = .idle
         startedAt = nil
+        runNote = ""
+        sourceDescription = "synthesized"
     }
 
-    func run(configuration: Configuration) {
+    func run(
+        configuration: Configuration,
+        photoImage: CGImage? = nil,
+        photoOriginalSize: CGSize? = nil
+    ) {
         cancel()
+        if configuration.sourceKind == .photo, photoImage == nil {
+            phase = .failed(message: "Photo source selected but no image was loaded.")
+            return
+        }
         let cases = Self.makeCases(configuration: configuration)
         let totalRuns = cases.count * (configuration.warmupRuns + configuration.measuredRuns)
         guard totalRuns > 0 else {
@@ -56,17 +92,57 @@ final class BenchRunner: ObservableObject {
         samples = []
         summaries = []
         startedAt = Date()
+        runNote = configuration.runNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        sourceDescription = Self.describeSource(
+            kind: configuration.sourceKind,
+            originalSize: photoOriginalSize
+        )
         phase = .running(currentIndex: 0, total: totalRuns, currentLabel: cases.first?.label ?? "")
 
         task = Task { [weak self] in
             guard let self else { return }
-            await self.execute(cases: cases, configuration: configuration, totalRuns: totalRuns)
+            await self.execute(
+                cases: cases,
+                configuration: configuration,
+                photoImage: photoImage,
+                totalRuns: totalRuns
+            )
+        }
+    }
+
+    private func makeImage(
+        for benchCase: BenchCase,
+        configuration: Configuration,
+        photoImage: CGImage?
+    ) -> CGImage? {
+        switch configuration.sourceKind {
+        case .synthesized:
+            return BenchFixture.makePhotoLike(side: benchCase.pixelSide)
+        case .photo:
+            guard let photo = photoImage else { return nil }
+            return BenchFixture.resizeToSquare(photo, side: benchCase.pixelSide)
+        }
+    }
+
+    private static func describeSource(
+        kind: Configuration.SourceKind,
+        originalSize: CGSize?
+    ) -> String {
+        switch kind {
+        case .synthesized:
+            return "synthesized"
+        case .photo:
+            if let s = originalSize {
+                return "photo \(Int(s.width))x\(Int(s.height))"
+            }
+            return "photo"
         }
     }
 
     private func execute(
         cases: [BenchCase],
         configuration: Configuration,
+        photoImage: CGImage?,
         totalRuns: Int
     ) async {
         var collected: [BenchSample] = []
@@ -74,7 +150,14 @@ final class BenchRunner: ObservableObject {
 
         for benchCase in cases {
             if Task.isCancelled { break }
-            let image = BenchFixture.makePhotoLike(side: benchCase.pixelSide)
+            guard let image = makeImage(
+                for: benchCase,
+                configuration: configuration,
+                photoImage: photoImage
+            ) else {
+                phase = .failed(message: "Photo source went away mid-run.")
+                return
+            }
             let runs = configuration.warmupRuns + configuration.measuredRuns
             for runIndex in 0..<runs {
                 if Task.isCancelled { break }
@@ -180,6 +263,10 @@ final class BenchRunner: ObservableObject {
             guard !measured.isEmpty else { continue }
             let totalsMs = measured.map { $0.totalSeconds * 1000 }
             let quantizesMs = measured.map { $0.quantizeSeconds * 1000 }
+            let n = Double(measured.count)
+            let decodeMean = measured.reduce(0.0) { $0 + $1.decodeSeconds * 1000 } / n
+            let sampleMean = measured.reduce(0.0) { $0 + $1.sampleSeconds * 1000 } / n
+            let quantizeMean = measured.reduce(0.0) { $0 + $1.quantizeSeconds * 1000 } / n
             let engine = measured.last?.engineUsed ?? "?"
             let errorCount = measured.filter { $0.errorMessage != nil }.count
             summaries.append(
@@ -193,6 +280,9 @@ final class BenchRunner: ObservableObject {
                     totalMaxMs: totalsMs.max() ?? 0,
                     quantizeP50ms: percentile(quantizesMs, p: 0.50),
                     quantizeP95ms: percentile(quantizesMs, p: 0.95),
+                    decodeMeanMs: decodeMean,
+                    sampleMeanMs: sampleMean,
+                    quantizeMeanMs: quantizeMean,
                     engineUsed: engine,
                     errorCount: errorCount
                 )

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchView.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchView.swift
@@ -1,0 +1,254 @@
+import SwiftUI
+
+struct BenchView: View {
+    @StateObject private var runner = BenchRunner()
+    @State private var configuration = BenchRunner.Configuration()
+
+    private let device = DeviceInfo.current
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                deviceCard
+
+                configurationCard
+
+                controlsRow
+
+                progressView
+
+                if !runner.summaries.isEmpty {
+                    summaryTable
+                }
+
+                if !runner.samples.isEmpty {
+                    rawSamplesTable
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Benchmarks")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Sections
+
+    private var deviceCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Device").font(.caption).foregroundStyle(.secondary)
+            HStack {
+                Text(device.model).font(.headline.monospaced())
+                Spacer()
+                Text("\(device.processorCount) cores").font(.caption).foregroundStyle(.secondary)
+            }
+            Text(device.osVersion).font(.caption).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var configurationCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Configuration").font(.headline)
+            Toggle("Auto downsample (1M cap, real-world)", isOn: $configuration.includeAutoDownsample)
+            Toggle("Raw (no downsample, GPU stress)", isOn: $configuration.includeRawDownsample)
+            Toggle("Include 8192² (high memory)", isOn: $configuration.include8K)
+            HStack {
+                Stepper(
+                    "Warmup runs: \(configuration.warmupRuns)",
+                    value: $configuration.warmupRuns,
+                    in: 0...3
+                )
+            }
+            HStack {
+                Stepper(
+                    "Measured runs: \(configuration.measuredRuns)",
+                    value: $configuration.measuredRuns,
+                    in: 1...10
+                )
+            }
+            Text(estimateLabel)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .disabled(runner.isRunning)
+    }
+
+    private var controlsRow: some View {
+        HStack(spacing: 12) {
+            Button {
+                runner.run(configuration: configuration)
+            } label: {
+                Label("Run Benchmarks", systemImage: "play.fill")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(runner.isRunning)
+
+            if runner.isRunning {
+                Button(role: .destructive) {
+                    runner.cancel()
+                } label: {
+                    Label("Cancel", systemImage: "stop.fill")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                }
+                .buttonStyle(.bordered)
+            } else if !runner.summaries.isEmpty {
+                shareMenu
+            }
+        }
+    }
+
+    private var shareMenu: some View {
+        Menu {
+            ShareLink(item: rawCSVFile()) { Label("Raw CSV", systemImage: "tablecells") }
+            ShareLink(item: summaryCSVFile()) { Label("Summary CSV", systemImage: "table") }
+            Button(role: .destructive) {
+                runner.reset()
+            } label: {
+                Label("Clear results", systemImage: "trash")
+            }
+        } label: {
+            Label("Export", systemImage: "square.and.arrow.up")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+        }
+        .menuStyle(.borderlessButton)
+    }
+
+    @ViewBuilder
+    private var progressView: some View {
+        switch runner.phase {
+        case .idle:
+            EmptyView()
+        case .running(let i, let total, let label):
+            VStack(alignment: .leading, spacing: 6) {
+                ProgressView(value: Double(i), total: Double(total))
+                Text("\(i)/\(total) · \(label)")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+        case .finished:
+            Label("Finished", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .failed(let msg):
+            Label(msg, systemImage: "xmark.octagon.fill")
+                .foregroundStyle(.red)
+        }
+    }
+
+    private var summaryTable: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Summary (post-warmup)").font(.headline)
+            HStack {
+                cellHeader("size", width: 70)
+                cellHeader("q", width: 50)
+                cellHeader("ds", width: 50)
+                cellHeader("p50", width: 70)
+                cellHeader("p95", width: 70)
+                cellHeader("min", width: 60)
+                cellHeader("max", width: 60)
+            }
+            .font(.caption2.monospaced())
+            .foregroundStyle(.secondary)
+            ForEach(runner.summaries) { s in
+                HStack {
+                    cell("\(s.benchCase.pixelSide)²", width: 70)
+                    cell(s.benchCase.quantizer.rawValue, width: 50)
+                    cell(s.benchCase.downsample.rawValue, width: 50)
+                    cell(fmt(s.totalP50ms), width: 70)
+                    cell(fmt(s.totalP95ms), width: 70)
+                    cell(fmt(s.totalMinMs), width: 60)
+                    cell(fmt(s.totalMaxMs), width: 60)
+                }
+                .font(.caption.monospaced())
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var rawSamplesTable: some View {
+        DisclosureGroup("Raw samples (\(runner.samples.count))") {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(runner.samples) { s in
+                    HStack(spacing: 6) {
+                        if s.isWarmup {
+                            Text("warm").foregroundStyle(.tertiary)
+                        }
+                        Text(s.caseId).lineLimit(1)
+                        Spacer()
+                        if let err = s.errorMessage {
+                            Text(err).foregroundStyle(.red).lineLimit(1)
+                        } else {
+                            Text(fmt(s.totalSeconds * 1000)).monospacedDigit()
+                        }
+                    }
+                    .font(.caption2.monospaced())
+                }
+            }
+            .padding(.top, 8)
+        }
+        .padding()
+        .background(.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Helpers
+
+    private var estimateLabel: String {
+        let cases = BenchRunner.makeCases(configuration: configuration)
+        let runs = cases.count * (configuration.warmupRuns + configuration.measuredRuns)
+        return "\(cases.count) cases · \(runs) runs"
+    }
+
+    private func cellHeader(_ text: String, width: CGFloat) -> some View {
+        Text(text).frame(width: width, alignment: .leading)
+    }
+
+    private func cell(_ text: String, width: CGFloat) -> some View {
+        Text(text).frame(width: width, alignment: .leading)
+    }
+
+    private func fmt(_ ms: Double) -> String {
+        if ms < 10 { return String(format: "%.2f", ms) }
+        return String(format: "%.0f", ms)
+    }
+
+    private func rawCSVFile() -> URL {
+        BenchExport.writeToTemp(
+            name: "palettekit-bench-raw-\(filenameTimestamp()).csv",
+            contents: BenchExport.rawCSV(
+                device: device,
+                startedAt: runner.startedAt,
+                samples: runner.samples
+            )
+        )
+    }
+
+    private func summaryCSVFile() -> URL {
+        BenchExport.writeToTemp(
+            name: "palettekit-bench-summary-\(filenameTimestamp()).csv",
+            contents: BenchExport.summaryCSV(
+                device: device,
+                summaries: runner.summaries
+            )
+        )
+    }
+
+    private func filenameTimestamp() -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyyMMdd-HHmmss"
+        return f.string(from: runner.startedAt ?? Date())
+    }
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchView.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Bench/BenchView.swift
@@ -1,8 +1,16 @@
+import CoreGraphics
+import PhotosUI
 import SwiftUI
 
 struct BenchView: View {
     @StateObject private var runner = BenchRunner()
     @State private var configuration = BenchRunner.Configuration()
+
+    @State private var photoItem: PhotosPickerItem?
+    @State private var photoImage: CGImage?
+    @State private var photoOriginalSize: CGSize?
+    @State private var photoLoadError: String?
+    @State private var isLoadingPhoto = false
 
     private let device = DeviceInfo.current
 
@@ -19,6 +27,7 @@ struct BenchView: View {
 
                 if !runner.summaries.isEmpty {
                     summaryTable
+                    BenchChart(summaries: runner.summaries)
                 }
 
                 if !runner.samples.isEmpty {
@@ -29,6 +38,36 @@ struct BenchView: View {
         }
         .navigationTitle("Benchmarks")
         .navigationBarTitleDisplayMode(.inline)
+        .onChange(of: photoItem) { _, newItem in
+            Task { await loadPhoto(from: newItem) }
+        }
+    }
+
+    private func loadPhoto(from item: PhotosPickerItem?) async {
+        guard let item else {
+            photoImage = nil
+            photoOriginalSize = nil
+            return
+        }
+        isLoadingPhoto = true
+        photoLoadError = nil
+        defer { isLoadingPhoto = false }
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self),
+                  let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
+                  let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+                photoLoadError = "Could not decode the selected photo."
+                photoImage = nil
+                photoOriginalSize = nil
+                return
+            }
+            photoImage = cgImage
+            photoOriginalSize = CGSize(width: cgImage.width, height: cgImage.height)
+        } catch {
+            photoLoadError = "Photo load failed: \(error.localizedDescription)"
+            photoImage = nil
+            photoOriginalSize = nil
+        }
     }
 
     // MARK: - Sections
@@ -37,11 +76,13 @@ struct BenchView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Device").font(.caption).foregroundStyle(.secondary)
             HStack {
-                Text(device.model).font(.headline.monospaced())
+                Text(device.marketingName).font(.headline)
                 Spacer()
                 Text("\(device.processorCount) cores").font(.caption).foregroundStyle(.secondary)
             }
-            Text(device.osVersion).font(.caption).foregroundStyle(.secondary)
+            Text("\(device.model) · \(device.osVersion)")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
@@ -50,27 +91,57 @@ struct BenchView: View {
     }
 
     private var configurationCard: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Text("Configuration").font(.headline)
-            Toggle("Auto downsample (1M cap, real-world)", isOn: $configuration.includeAutoDownsample)
-            Toggle("Raw (no downsample, GPU stress)", isOn: $configuration.includeRawDownsample)
-            Toggle("Include 8192² (high memory)", isOn: $configuration.include8K)
-            HStack {
-                Stepper(
-                    "Warmup runs: \(configuration.warmupRuns)",
-                    value: $configuration.warmupRuns,
-                    in: 0...3
-                )
+
+            sourceSection
+
+            Divider()
+
+            configToggle(
+                "Auto downsample (1M cap, real-world)",
+                isOn: $configuration.includeAutoDownsample,
+                info: .autoDownsample
+            )
+            configToggle(
+                "Raw (no downsample, GPU stress)",
+                isOn: $configuration.includeRawDownsample,
+                info: .rawDownsample
+            )
+            configToggle(
+                "Include 8192² (high memory)",
+                isOn: $configuration.include8K,
+                info: .include8K
+            )
+            configStepper(
+                "Warmup runs: \(configuration.warmupRuns)",
+                value: $configuration.warmupRuns,
+                in: 0...3,
+                info: .warmupRuns
+            )
+            configStepper(
+                "Measured runs: \(configuration.measuredRuns)",
+                value: $configuration.measuredRuns,
+                in: 1...10,
+                info: .measuredRuns
+            )
+
+            HStack(spacing: 6) {
+                Text("Run note").font(.footnote)
+                InfoButton(info: .runNote)
+                Spacer()
             }
-            HStack {
-                Stepper(
-                    "Measured runs: \(configuration.measuredRuns)",
-                    value: $configuration.measuredRuns,
-                    in: 1...10
-                )
-            }
+            TextField(
+                "optional — e.g. \"quiet, room temp\"",
+                text: $configuration.runNote
+            )
+            .textFieldStyle(.roundedBorder)
+            .font(.footnote)
+            .autocorrectionDisabled(true)
+            .textInputAutocapitalization(.never)
+
             Text(estimateLabel)
-                .font(.caption)
+                .font(.caption2)
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -80,31 +151,177 @@ struct BenchView: View {
         .disabled(runner.isRunning)
     }
 
+    @ViewBuilder
+    private var sourceSection: some View {
+        HStack(spacing: 6) {
+            Text("Source").font(.footnote)
+            InfoButton(info: .source)
+            Spacer()
+        }
+        Picker("Source", selection: $configuration.sourceKind) {
+            Text("Synthesized").tag(BenchRunner.Configuration.SourceKind.synthesized)
+            Text("Photo").tag(BenchRunner.Configuration.SourceKind.photo)
+        }
+        .pickerStyle(.segmented)
+        .font(.footnote)
+
+        if configuration.sourceKind == .photo {
+            photoPickerRow
+        }
+    }
+
+    private var photoPickerRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                photoThumbnail
+                VStack(alignment: .leading, spacing: 4) {
+                    if let size = photoOriginalSize {
+                        Text("\(Int(size.width))×\(Int(size.height))")
+                            .font(.caption.monospaced())
+                    } else if isLoadingPhoto {
+                        Text("Loading…").font(.caption).foregroundStyle(.secondary)
+                    } else {
+                        Text("No photo selected").font(.caption).foregroundStyle(.secondary)
+                    }
+                    Text("center-cropped & resized to each grid size")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                PhotosPicker(
+                    selection: $photoItem,
+                    matching: .images,
+                    photoLibrary: .shared()
+                ) {
+                    Label(photoImage == nil ? "Pick" : "Change", systemImage: "photo")
+                        .font(.footnote)
+                }
+                .buttonStyle(.bordered)
+            }
+            if let err = photoLoadError {
+                Text(err)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var photoThumbnail: some View {
+        if let cgImage = photoImage {
+            Image(decorative: cgImage, scale: 1, orientation: .up)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 56, height: 56)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        } else {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.tertiary)
+                .frame(width: 56, height: 56)
+                .overlay {
+                    Image(systemName: "photo")
+                        .foregroundStyle(.secondary)
+                }
+        }
+    }
+
+    private func configToggle(
+        _ title: String,
+        isOn: Binding<Bool>,
+        info: BenchInfo
+    ) -> some View {
+        Toggle(isOn: isOn) {
+            HStack(spacing: 6) {
+                Text(title).font(.footnote)
+                InfoButton(info: info)
+            }
+        }
+    }
+
+    private func configStepper(
+        _ title: String,
+        value: Binding<Int>,
+        in range: ClosedRange<Int>,
+        info: BenchInfo
+    ) -> some View {
+        Stepper(value: value, in: range) {
+            HStack(spacing: 6) {
+                Text(title).font(.footnote)
+                InfoButton(info: info)
+            }
+        }
+    }
+
     private var controlsRow: some View {
         HStack(spacing: 12) {
-            Button {
-                runner.run(configuration: configuration)
+            primaryButton
+            secondaryButton
+        }
+    }
+
+    @ViewBuilder
+    private var primaryButton: some View {
+        if hasResults && !runner.isRunning {
+            Button(role: .destructive) {
+                performReset()
             } label: {
-                Label("Run Benchmarks", systemImage: "play.fill")
+                Label("Reset", systemImage: "arrow.counterclockwise")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.bordered)
+            .tint(.red)
+        } else {
+            Button {
+                runner.run(
+                    configuration: configuration,
+                    photoImage: photoImage,
+                    photoOriginalSize: photoOriginalSize
+                )
+            } label: {
+                Label("Run", systemImage: "play.fill")
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 6)
             }
             .buttonStyle(.borderedProminent)
-            .disabled(runner.isRunning)
-
-            if runner.isRunning {
-                Button(role: .destructive) {
-                    runner.cancel()
-                } label: {
-                    Label("Cancel", systemImage: "stop.fill")
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 6)
-                }
-                .buttonStyle(.bordered)
-            } else if !runner.summaries.isEmpty {
-                shareMenu
-            }
+            .disabled(runner.isRunning || !canRun)
         }
+    }
+
+    private var canRun: Bool {
+        switch configuration.sourceKind {
+        case .synthesized: return true
+        case .photo: return photoImage != nil
+        }
+    }
+
+    @ViewBuilder
+    private var secondaryButton: some View {
+        if runner.isRunning {
+            Button(role: .destructive) {
+                runner.cancel()
+            } label: {
+                Label("Cancel", systemImage: "stop.fill")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.bordered)
+        } else if hasResults {
+            shareMenu
+        }
+    }
+
+    private var hasResults: Bool {
+        !runner.samples.isEmpty
+    }
+
+    private func performReset() {
+        runner.reset()
+        configuration = BenchRunner.Configuration()
+        photoItem = nil
+        photoImage = nil
+        photoOriginalSize = nil
+        photoLoadError = nil
     }
 
     private var shareMenu: some View {
@@ -121,7 +338,7 @@ struct BenchView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 6)
         }
-        .menuStyle(.borderlessButton)
+        .buttonStyle(.bordered)
     }
 
     @ViewBuilder
@@ -130,46 +347,104 @@ struct BenchView: View {
         case .idle:
             EmptyView()
         case .running(let i, let total, let label):
-            VStack(alignment: .leading, spacing: 6) {
-                ProgressView(value: Double(i), total: Double(total))
-                Text("\(i)/\(total) · \(label)")
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .center, spacing: 6) {
+                    Text("\(i)/\(total)")
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                    ProgressView()
+                        .controlSize(.mini)
+                    Spacer()
+                    Text(label)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                if runner.failureCount > 0 {
+                    failureChip(count: runner.failureCount, message: runner.firstFailureMessage)
+                }
             }
         case .finished:
-            Label("Finished", systemImage: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+            if runner.failureCount > 0 {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label(
+                        "Finished with \(runner.failureCount) failure\(runner.failureCount == 1 ? "" : "s")",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .foregroundStyle(.orange)
+                    if let msg = runner.firstFailureMessage {
+                        Text(msg)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(3)
+                            .padding(.leading, 28)
+                    }
+                }
+            } else {
+                Label("Finished", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
         case .failed(let msg):
             Label(msg, systemImage: "xmark.octagon.fill")
                 .foregroundStyle(.red)
         }
     }
 
+    private func failureChip(count: Int, message: String?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Label(
+                "\(count) failed run\(count == 1 ? "" : "s") so far",
+                systemImage: "exclamationmark.triangle.fill"
+            )
+            .font(.caption2)
+            .foregroundStyle(.orange)
+            if let message {
+                Text(message)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .padding(.leading, 22)
+            }
+        }
+    }
+
     private var summaryTable: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Summary (post-warmup)").font(.headline)
-            HStack {
-                cellHeader("size", width: 70)
-                cellHeader("q", width: 50)
-                cellHeader("ds", width: 50)
-                cellHeader("p50", width: 70)
-                cellHeader("p95", width: 70)
-                cellHeader("min", width: 60)
-                cellHeader("max", width: 60)
-            }
-            .font(.caption2.monospaced())
-            .foregroundStyle(.secondary)
-            ForEach(runner.summaries) { s in
-                HStack {
-                    cell("\(s.benchCase.pixelSide)²", width: 70)
-                    cell(s.benchCase.quantizer.rawValue, width: 50)
-                    cell(s.benchCase.downsample.rawValue, width: 50)
-                    cell(fmt(s.totalP50ms), width: 70)
-                    cell(fmt(s.totalP95ms), width: 70)
-                    cell(fmt(s.totalMinMs), width: 60)
-                    cell(fmt(s.totalMaxMs), width: 60)
+            Text("ms · p50 = median, p95 = tail")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 4) {
+                GridRow {
+                    Text("size")
+                    Text("q")
+                    Text("ds")
+                    Text("p50").gridColumnAlignment(.trailing)
+                    Text("p95").gridColumnAlignment(.trailing)
+                    Text("max").gridColumnAlignment(.trailing)
                 }
-                .font(.caption.monospaced())
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+
+                ForEach(runner.summaries) { s in
+                    GridRow {
+                        HStack(spacing: 4) {
+                            Text("\(s.benchCase.pixelSide)²")
+                            if s.errorCount > 0 {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.orange)
+                            }
+                        }
+                        Text(s.benchCase.quantizer.rawValue)
+                        Text(s.benchCase.downsample.rawValue)
+                        Text(fmt(s.totalP50ms)).gridColumnAlignment(.trailing)
+                        Text(fmt(s.totalP95ms)).gridColumnAlignment(.trailing)
+                        Text(fmt(s.totalMaxMs)).gridColumnAlignment(.trailing)
+                    }
+                    .font(.caption2.monospaced())
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -179,19 +454,27 @@ struct BenchView: View {
     }
 
     private var rawSamplesTable: some View {
-        DisclosureGroup("Raw samples (\(runner.samples.count))") {
+        DisclosureGroup("Raw samples (\(runner.samples.count)) — total ms per run") {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(runner.samples) { s in
                     HStack(spacing: 6) {
                         if s.isWarmup {
-                            Text("warm").foregroundStyle(.tertiary)
+                            Text("w").foregroundStyle(.tertiary)
                         }
-                        Text(s.caseId).lineLimit(1)
-                        Spacer()
+                        Text(s.caseId)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer(minLength: 4)
                         if let err = s.errorMessage {
-                            Text(err).foregroundStyle(.red).lineLimit(1)
+                            Text(err)
+                                .foregroundStyle(.red)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
                         } else {
-                            Text(fmt(s.totalSeconds * 1000)).monospacedDigit()
+                            HStack(spacing: 2) {
+                                Text(fmt(s.totalSeconds * 1000)).monospacedDigit()
+                                Text("ms").foregroundStyle(.secondary)
+                            }
                         }
                     }
                     .font(.caption2.monospaced())
@@ -212,14 +495,6 @@ struct BenchView: View {
         return "\(cases.count) cases · \(runs) runs"
     }
 
-    private func cellHeader(_ text: String, width: CGFloat) -> some View {
-        Text(text).frame(width: width, alignment: .leading)
-    }
-
-    private func cell(_ text: String, width: CGFloat) -> some View {
-        Text(text).frame(width: width, alignment: .leading)
-    }
-
     private func fmt(_ ms: Double) -> String {
         if ms < 10 { return String(format: "%.2f", ms) }
         return String(format: "%.0f", ms)
@@ -231,6 +506,8 @@ struct BenchView: View {
             contents: BenchExport.rawCSV(
                 device: device,
                 startedAt: runner.startedAt,
+                runNote: runner.runNote,
+                sourceDescription: runner.sourceDescription,
                 samples: runner.samples
             )
         )
@@ -241,6 +518,8 @@ struct BenchView: View {
             name: "palettekit-bench-summary-\(filenameTimestamp()).csv",
             contents: BenchExport.summaryCSV(
                 device: device,
+                runNote: runner.runNote,
+                sourceDescription: runner.sourceDescription,
                 summaries: runner.summaries
             )
         )

--- a/Examples/PaletteKitDemo/PaletteKitDemo/ContentView.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/ContentView.swift
@@ -56,6 +56,16 @@ struct ContentView: View {
                 .padding()
             }
             .navigationTitle("PaletteKit Demo")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink {
+                        BenchView()
+                    } label: {
+                        Image(systemName: "speedometer")
+                    }
+                    .accessibilityLabel("Benchmarks")
+                }
+            }
         }
         .onChange(of: pickedItem) { _, newValue in
             Task { await loadImage(from: newValue) }

--- a/README.md
+++ b/README.md
@@ -68,34 +68,18 @@ dependencies: [
 
 Minimum iOS 17 · Swift 6.0 · Xcode 16+.
 
-## API at a glance
+## API
 
-| Call | Returns |
-|---|---|
-| `extractor.dominantColor(from:options:)` | `PaletteColor?` |
-| `extractor.palette(from:options:)` | `Palette` |
-| `extractor.swatches(from:options:)` | `SwatchMap` |
+```swift
+extractor.dominantColor(from:)   // PaletteColor?
+extractor.palette(from:)          // Palette
+extractor.swatches(from:)         // SwatchMap
+```
 
-| `ImageSource` case | Input |
-|---|---|
-| `.cgImage(CGImage)` | already-decoded image |
-| `.data(Data)` | raw image data (JPEG, HEIC, PNG, …) |
-| `.url(URL)` | local or remote image URL |
-
-| `ExtractionOptions` | Default | Purpose |
-|---|---|---|
-| `colorCount` | 10 | palette size (2–256) |
-| `quality` | `.stride(10)` | pixel stride |
-| `colorSpace` | `.oklch` | quantization space |
-| `ignoreWhite` | `true` | filter near-white pixels |
-| `whiteThreshold` | 250 | channel threshold for "white" |
-| `alphaThreshold` | 125 | drop pixels with alpha below |
-| `minSaturation` | 0 | drop low-saturation pixels |
-| `fallbackStrategy` | `.relax` | empty-filter recovery |
-| `autoOrient` | `true` | respect EXIF orientation |
-| `downsample` | `.automatic(maxPixels: 1_000_000)` | decode-time downsample |
-| `quantizer` | `.auto` | `.auto` / `.cpu` / `.metal` / `.custom` |
-| `collectTimings` | `false` | populate `palette.timings` |
+`ImageSource` cases (`.cgImage` / `.data` / `.url`) and the full
+`ExtractionOptions` surface (`colorCount`, `quality`, `colorSpace`,
+`downsample`, `quantizer`, …) are documented in the
+[DocC reference](https://swiftpackageindex.com/2dubu/PaletteKit/documentation/palettekit).
 
 ## Color space handling
 
@@ -171,6 +155,22 @@ make demo-app    # generate PaletteKitDemo.xcodeproj and open it in Xcode
 
 See [`Examples/PaletteKitDemo/README.md`](./Examples/PaletteKitDemo/README.md)
 for how the app is wired.
+
+## Benchmark on your device
+
+The demo app ships with an on-device benchmark harness. Pick a real
+photo or use the synthesized fixture, vary size / quantizer /
+downsample, and export per-stage timings (decode, sample, quantize)
+as CSV for cross-device comparison.
+
+```bash
+make demo-app    # build & run on a connected iPhone, tap the
+                 # speedometer icon in the top-right
+```
+
+Tap **Run**, watch the chart fill in, then **Export** as Raw CSV or
+Summary CSV via the share sheet. Save exports under `benchmark/`
+(gitignored) for local-only analysis.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                         
                                                                                                                                                                                                     
  - Add an on-device benchmark harness in `Examples/PaletteKitDemo` so PaletteKit performance claims can be measured per-device, per-content. Pick a real photo or a synthesized fixture, vary size /
   quantizer / downsample, and export per-stage timings as CSV.                                                                                                                                      
  - Apply bench-first methodology — the harness gates v1.x decisions on CPU/GPU work. The first round on iPhone 15 Pro confirmed that single-shot extraction is fast enough at default options that
  progressive extraction is not worth shipping; v1.1 ships the harness itself instead.                                                                                                               
  - Trim README API surface to a method skeleton + DocC link to reduce drift; add a "Benchmark on your device" section.                                                                 
                                                                                                                                                                                                     
  ## What's included                                                                                                                                                                                 
                                                                                                                                                                                         
  ### Bench harness (`Examples/PaletteKitDemo/PaletteKitDemo/Bench/`)                                                                                                                                
  - `BenchModels` — case definitions (size × quantizer × downsample), per-sample structures, summary aggregates with mean per-stage timings, marketing-name mapping for hardware identifiers.        
  - `BenchFixture` — deterministic synthesized image (gradient + 5 colored blobs + per-pixel noise), plus `resizeToSquare(_:side:)` for real-photo input center-cropped to each grid size.
  - `BenchRunner` (`@MainActor` `ObservableObject`) — orchestrates warmup + measured runs, captures `ExtractionTimings` per sample, computes p50/p95/min/max + per-stage means, surfaces failure     
  counts.                                                                                                                                                                               
  - `BenchView` — Source picker (Synthesized / Photo) with `PhotosPicker`, Configuration card with per-row `InfoButton` popovers, Run/Reset/Cancel state machine, `Grid`-based summary table,        
  stacked-bar chart, raw samples disclosure.                   
  - `BenchChart` (Swift Charts) — horizontal stacked bars showing decode / sample / quantize means per case.
  - `BenchExport` — Raw and Summary CSV with headers including PaletteKit version, device identifier, marketing name, source descriptor (`synthesized` or `photo WxH`), and optional run note.       
  - `BenchInfo` — popover content for each Configuration field; reusable `InfoButton` component (compact-adapted on iPhone, fixed-width with text wrap).                                             
                                                                                                                                                                                                     
  ### Repo                                                                                                                                                                                           
  - README "## API at a glance" table (~30 lines) replaced by a method skeleton and a DocC reference link. `ExtractionOptions` defaults now live in `Options.md` as the single source of truth.      
  - README "## Benchmark on your device" section introduces the harness and the `benchmark/` convention.                                                                                
  - `.gitignore` adds `benchmark/` so CSV exports stay local without leaking device-specific results into the repo.                                                                                  
                                                                                                                                                                                                     
  ## Methodology notes                                                                                                                                                                               
                                                                                                                                                                                                     
  The harness exists because v1.0 shipped with provisional CPU/GPU thresholds (`metalAutoThreshold = 500_000`) and a `quality.stride` default that no one had measured under load. v1.1 ships the    
  measurement infrastructure first; v1.x feature work queues behind it.                                                                                                                              
                                                                                                                                                                                                     
  Findings from the first round (iPhone 15 Pro, both synthesized and a 12 MP photo):                                                                                                                 
  - Default options (`Downsample.automatic(maxPixels: 1_000_000)`) flatten quantize cost to ~80–140 ms regardless of input size. Metal vs CPU differ by <5 ms (within noise).                        
  - Metal becomes meaningfully faster (~5–10%) only when `Downsample.disabled` AND sampled pixel count ≥ ~1M — essentially the 4096²+ raw case.                                                      
  - The synthesized fixture underestimates real-world latency by 30–60% at small sizes — real photos populate more histogram bins, so MMCQ's median-cut PQ runs longer.                              
  - Decode + sample become the dominant cost in raw mode at 4096²+ inputs (>60% of total at 8K). Metal does not accelerate those stages, capping its real-world ceiling.                
                                                                                                                                                                                                     
  Findings stay local (`memory/`); README / DESIGN_SPEC / threshold corrections accumulate for a single batch update around v1.2 instead of churning per-discovery.                                  
                                                                                                                                                                                        
  ## Test plan                                                                                                                                                                                       
                                                                                                                                                                                                     
  - [x] `swift test` — existing PaletteKit tests pass (no library changes in this PR).                                                                                                               
  - [x] `make demo-app` regenerates the Xcode project; iOS simulator build succeeds.                                                                                                                 
  - [x] Bench screen renders; info popovers expand with text wrap; source picker switches Synthesized ↔ Photo; `PhotosPicker` loads CGImage and shows thumbnail with original dimensions.            
  - [x] On-device runs (iPhone 15 Pro / A17 Pro): three matrix configurations executed (auto-only, raw-only, photo+raw); CSV exports include all expected header lines and per-stage columns; chart  
  renders bars correctly.                                                                                                                                                                            
  - [x] Reset returns the screen to first-entry state (configuration + samples + photo selection cleared).
  - [x] CSV header reflects PaletteKit version, hardware identifier, marketing name, source descriptor, optional run note.