### PR TITLE
v1.6: PaletteMeshGraphic — SwiftUI mesh gradient primitive (iOS 18+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to PaletteKit are documented here.
+
+## 1.6.0
+
+### Added
+- `PaletteMeshGraphic` — SwiftUI multi-color mesh gradient primitive on
+  top of iOS 18+ `MeshGradient`. Sibling to `PaletteGraphic`.
+  - `gridSize`: `.compact` (2×2), `.standard` (3×3, default), `.rich` (4×4)
+  - `makeImage(size:scale:)`: ImageRenderer-based UIImage export
+  - Color slots are allocated proportional to each palette color's
+    `population`, so the mesh inherits the source photo's color dominance.
+    `PaletteMeshGraphic` deliberately does **not** consume `SwatchMap` —
+    callers only need a `Palette`.

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Card/MeshLabView.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Card/MeshLabView.swift
@@ -1,0 +1,57 @@
+import PaletteKit
+import SwiftUI
+
+@available(iOS 18.0, *)
+struct MeshLabView: View {
+    let palette: Palette
+
+    @State private var gridSize: PaletteMeshGraphic.GridSize = .standard
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                PaletteMeshGraphic(
+                    palette: palette,
+                    configuration: .init(gridSize: gridSize)
+                )
+                .frame(height: 320)
+                .clipShape(RoundedRectangle(cornerRadius: 24))
+                .padding(.horizontal)
+
+                gridPicker
+                exportButton
+            }
+            .padding(.vertical)
+        }
+        .navigationTitle("Mesh")
+    }
+
+    private var gridPicker: some View {
+        Picker("Grid size", selection: $gridSize) {
+            Text("Compact (2\u{d7}2)").tag(PaletteMeshGraphic.GridSize.compact)
+            Text("Standard (3\u{d7}3)").tag(PaletteMeshGraphic.GridSize.standard)
+            Text("Rich (4\u{d7}4)").tag(PaletteMeshGraphic.GridSize.rich)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+    }
+
+    @MainActor
+    private var exportButton: some View {
+        Button {
+            let img = PaletteMeshGraphic(
+                palette: palette,
+                configuration: .init(gridSize: gridSize)
+            ).makeImage(size: CGSize(width: 1080, height: 1080))
+            if let img, let data = img.pngData() {
+                let url = URL(fileURLWithPath: NSTemporaryDirectory())
+                    .appendingPathComponent("PaletteMesh-\(UUID().uuidString).png")
+                try? data.write(to: url)
+                print("Exported mesh to \(url.path)")
+            }
+        } label: {
+            Label("Export as PNG", systemImage: "square.and.arrow.up")
+        }
+        .padding(.horizontal)
+    }
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/ContentView.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/ContentView.swift
@@ -119,6 +119,10 @@ struct ContentView: View {
                 if let palette, !palette.isEmpty {
                     cardEntry(palette: palette)
                 }
+
+                if #available(iOS 18.0, *), let palette, !palette.isEmpty {
+                    meshEntry(palette: palette)
+                }
             }
         }
     }
@@ -131,6 +135,26 @@ struct ContentView: View {
             HStack {
                 Image(systemName: "wand.and.rays")
                 Text("Generate Graphic")
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding()
+            .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+
+    @available(iOS 18.0, *)
+    @ViewBuilder
+    private func meshEntry(palette: Palette) -> some View {
+        NavigationLink {
+            MeshLabView(palette: palette)
+        } label: {
+            HStack {
+                Image(systemName: "circle.grid.3x3.fill")
+                Text("Generate Mesh")
                 Spacer()
                 Image(systemName: "chevron.right")
                     .font(.footnote)

--- a/PaletteKit.docc/Tutorials/Card.md
+++ b/PaletteKit.docc/Tutorials/Card.md
@@ -113,3 +113,37 @@ AsyncPaletteGraphic(image: .url(url)) {
 .frame(width: 320, height: 320)
 .clipShape(RoundedRectangle(cornerRadius: 24))
 ```
+
+## Mesh gradient (iOS 18+)
+
+For a softer, multi-directional gradient, use ``PaletteMeshGraphic``. It is
+a SwiftUI primitive built on top of Apple's native `MeshGradient` (iOS 18+):
+
+```swift
+PaletteMeshGraphic(palette: palette)
+    .frame(width: 320, height: 320)
+    .clipShape(RoundedRectangle(cornerRadius: 24))
+```
+
+Unlike ``PaletteGraphic``, ``PaletteMeshGraphic`` does **not** take a
+``SwatchMap`` — it allocates slots proportional to each palette color's
+population, so the mesh inherits the source photo's color dominance
+directly. Callers who only need a mesh can skip the extra
+`extractor.swatches(from:)` call.
+
+Tune the result with ``PaletteMeshGraphic/Configuration``:
+
+- ``PaletteMeshGraphic/GridSize`` — `.compact` (2×2), `.standard` (3×3,
+  default), `.rich` (4×4). Larger grids read smoother but need a more
+  color-diverse palette.
+
+For a static `UIImage` (sharing, caching), call
+``PaletteMeshGraphic/makeImage(size:scale:)``:
+
+```swift
+let image: UIImage? = PaletteMeshGraphic(palette: palette)
+    .makeImage(size: CGSize(width: 1080, height: 1080))
+```
+
+> Tip: ``PaletteMeshGraphic/makeImage(size:scale:)`` must be called from
+> the main actor (it uses SwiftUI's `ImageRenderer`).

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ don't need to run it.
 - **v1.3** ✅ shipped — SwiftUI ShapeStyle conformance + idiomatic UIKit integration.
 - **v1.4** ✅ shipped — `PaletteGraphic` + `PaletteGraphicView` palette-driven graphic primitives.
 - **v1.5** ✅ shipped — `AsyncPaletteGraphic` + `AsyncPaletteGraphicView` async-loading wrappers with `PaletteCache`.
-- **v1.6** — `PaletteMeshGraphic` (iOS 18+ multi-color mesh primitive) + `SwatchMap` ergonomics (`titleTextColor(for:fallback:)` etc., eliminating `??` chain boilerplate).
+- **v1.6** ✅ shipped — `PaletteMeshGraphic` (iOS 18+ multi-color mesh primitive on top of SwiftUI's native `MeshGradient`).
+- **v1.7** — `SwatchMap` ergonomics (`titleTextColor(for:fallback:)` etc., eliminating `??` chain boilerplate).
 - **v2.0** — `observe()`: live video / camera frame stream → `AsyncStream<Palette>`.
 - **v2.1** — `PaletteKitInsights`: FoundationModels captions, color naming, custom instructions on iOS 26+ (separate optional module).
 

--- a/Sources/PaletteKit/Graphic/Mesh/PaletteMeshGraphic.swift
+++ b/Sources/PaletteKit/Graphic/Mesh/PaletteMeshGraphic.swift
@@ -1,0 +1,107 @@
+#if canImport(SwiftUI) && canImport(UIKit)
+import SwiftUI
+import UIKit
+
+/// Palette-driven mesh gradient primitive for SwiftUI (iOS 18+).
+///
+/// Sibling to ``PaletteGraphic`` with the same call shape, different
+/// visual character. Renders via SwiftUI's native `MeshGradient`.
+///
+/// ```swift
+/// PaletteMeshGraphic(palette: palette)
+///     .frame(width: 320, height: 320)
+///     .clipShape(RoundedRectangle(cornerRadius: 24))
+/// ```
+@available(iOS 18.0, *)
+public struct PaletteMeshGraphic: View {
+    public let palette: Palette
+    public let configuration: Configuration
+
+    public init(
+        palette: Palette,
+        configuration: Configuration = .init()
+    ) {
+        self.palette = palette
+        self.configuration = configuration
+    }
+
+    public var body: some View {
+        let seed = PaletteMeshGraphicResolver.paletteSeed(palette: palette)
+        let points = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: configuration.gridSize,
+            paletteSeed: seed
+        )
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: palette,
+            gridSize: configuration.gridSize
+        )
+        return MeshGradient(
+            width: configuration.gridSize.width,
+            height: configuration.gridSize.height,
+            points: points,
+            colors: colors.map { Color(UIColor($0)) }
+        )
+    }
+
+    /// Render this graphic to a `UIImage` at the given logical size.
+    ///
+    /// **Must be called from the main actor** (`ImageRenderer` constraint).
+    /// `scale` defaults to `2.0` for predictable output regardless of caller
+    /// context; pass an explicit value for device-accurate rendering.
+    ///
+    /// Returns `nil` if `size` or `scale` is non-positive, or if
+    /// `ImageRenderer` fails to allocate the backing image.
+    @MainActor
+    public func makeImage(size: CGSize, scale: CGFloat = 2.0) -> UIImage? {
+        guard size.width > 0, size.height > 0, scale > 0 else { return nil }
+        let renderer = ImageRenderer(
+            content: self.frame(width: size.width, height: size.height)
+        )
+        renderer.scale = scale
+        return renderer.uiImage
+    }
+}
+
+@available(iOS 18.0, *)
+extension PaletteMeshGraphic {
+    public struct Configuration: Sendable, Equatable, Hashable {
+        /// Number of mesh control points per axis. Default ``GridSize/standard``.
+        public var gridSize: GridSize
+
+        public init(
+            gridSize: GridSize = .standard
+        ) {
+            self.gridSize = gridSize
+        }
+    }
+
+    /// Square grid size for mesh control points.
+    ///
+    /// All grids are N×N: ``compact`` (2×2), ``standard`` (3×3), ``rich`` (4×4).
+    /// Larger grids read smoother but require a more color-diverse palette.
+    public enum GridSize: Sendable, Equatable, Hashable {
+        /// 2×2 grid — 4 colors. Minimal mesh: only corner points, so the
+        /// resolver's organic jitter has no visible effect.
+        case compact
+        /// 3×3 grid — 9 colors. Default; balanced detail and palette identity.
+        case standard
+        /// 4×4 grid — 16 colors. Smoothest blend; best for color-diverse palettes.
+        case rich
+
+        /// Columns of mesh control points.
+        public var width: Int {
+            switch self {
+            case .compact: return 2
+            case .standard: return 3
+            case .rich: return 4
+            }
+        }
+
+        /// Rows of mesh control points.
+        public var height: Int { width }
+
+        /// Total number of colors / control points (`width * height`).
+        public var colorCount: Int { width * height }
+    }
+}
+#endif

--- a/Sources/PaletteKit/Graphic/Mesh/PaletteMeshGraphicResolver.swift
+++ b/Sources/PaletteKit/Graphic/Mesh/PaletteMeshGraphicResolver.swift
@@ -1,0 +1,205 @@
+#if canImport(UIKit)
+import Foundation
+import simd
+
+@available(iOS 18.0, *)
+internal enum PaletteMeshGraphicResolver {
+    /// Deterministic, seedable PRNG used for anchor jitter so that the
+    /// same palette + configuration always produces the same mesh.
+    /// Algorithm: SplitMix64 (Vigna). Internal — not part of the API.
+    internal struct SplitMix64 {
+        private var state: UInt64
+
+        init(seed: UInt64) {
+            self.state = seed
+        }
+
+        mutating func next() -> UInt64 {
+            state &+= 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z &>> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z &>> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z &>> 31)
+        }
+
+        /// Uniform value in `[-1.0, 1.0)`. Useful for symmetric jitter.
+        mutating func nextDouble() -> Double {
+            let raw = next() >> 11               // 53 bits
+            let unit = Double(raw) / Double(1 << 53)   // [0, 1)
+            return unit * 2.0 - 1.0
+        }
+    }
+
+    /// Stable `UInt64` derived from the palette's color sequence. Used as a
+    /// `SplitMix64` seed so the same palette produces the same jitter pattern
+    /// across renders.
+    static func paletteSeed(palette: Palette) -> UInt64 {
+        var hasher = Hasher()
+        for color in palette.colors {
+            hasher.combine(color.rgb)
+        }
+        return UInt64(bitPattern: Int64(hasher.finalize()))
+    }
+
+    /// Returns mesh control points in row-major order
+    /// (row 0 = top, x increasing left→right).
+    ///
+    /// Corner points stay fixed so the mesh always covers the frame;
+    /// top/bottom edge points receive small X-axis jitter, left/right edge
+    /// points receive Y-axis jitter, and internal points jitter on both
+    /// axes. The jitter amount is fixed (~0.3 × cellSize × 0.49) — a soft
+    /// organic feel without exposing a knob. `compact` (2×2) has corners
+    /// only, so jitter is a no-op there.
+    static func resolvePoints(
+        gridSize: PaletteMeshGraphic.GridSize,
+        paletteSeed: UInt64
+    ) -> [SIMD2<Float>] {
+        let n = gridSize.width
+        let denom = Float(max(n - 1, 1))
+        // Fixed organic amount. 0.49 is the cell-boundary safety factor;
+        // 0.3 is the scaled portion of it.
+        let cellSize: Float = denom > 0 ? 1.0 / denom : 0
+        let maxOffset = Float(0.3) * 0.49 * cellSize
+
+        var rng = SplitMix64(seed: paletteSeed)
+        var pts: [SIMD2<Float>] = []
+        pts.reserveCapacity(gridSize.colorCount)
+
+        for row in 0..<n {
+            for col in 0..<n {
+                let baseX = Float(col) / denom
+                let baseY = Float(row) / denom
+                let isLeftRightEdge = (col == 0 || col == n - 1)
+                let isTopBottomEdge = (row == 0 || row == n - 1)
+                let isCorner = isLeftRightEdge && isTopBottomEdge
+
+                if isCorner || maxOffset == 0 {
+                    pts.append(SIMD2<Float>(baseX, baseY))
+                } else if isTopBottomEdge {
+                    let dx = Float(rng.nextDouble()) * maxOffset
+                    pts.append(SIMD2<Float>(baseX + dx, baseY))
+                } else if isLeftRightEdge {
+                    let dy = Float(rng.nextDouble()) * maxOffset
+                    pts.append(SIMD2<Float>(baseX, baseY + dy))
+                } else {
+                    let dx = Float(rng.nextDouble()) * maxOffset
+                    let dy = Float(rng.nextDouble()) * maxOffset
+                    pts.append(SIMD2<Float>(baseX + dx, baseY + dy))
+                }
+            }
+        }
+        return pts
+    }
+
+    /// Returns exactly `gridSize.colorCount` colors in row-major order to
+    /// match ``resolvePoints``.
+    ///
+    /// Slots are allocated **proportional to each color's
+    /// ``PaletteColor/population``** so the mesh inherits the source photo's
+    /// dominance distribution. Colors with insufficient weight to claim a
+    /// slot are dropped — they would not be visually present in the photo
+    /// either. The chosen colors are then OKLCH-sorted onto the grid so
+    /// lighter colors read toward the top, more saturated colors toward the
+    /// right.
+    static func resolveColors(
+        palette: Palette,
+        gridSize: PaletteMeshGraphic.GridSize
+    ) -> [PaletteColor] {
+        let slotCount = gridSize.colorCount
+
+        // 1. Empty palette → all slots clear/black.
+        guard !palette.colors.isEmpty else {
+            return Array(repeating: PaletteColor(r: 0, g: 0, b: 0), count: slotCount)
+        }
+
+        // 2. Population-weighted slot allocation (largest remainder method).
+        let weighted = allocateSlots(palette: palette, slotCount: slotCount)
+
+        // 3. Materialize the slot assignments into a flat color array.
+        var working: [PaletteColor] = []
+        working.reserveCapacity(slotCount)
+        for (color, count) in weighted {
+            for _ in 0..<count {
+                working.append(color)
+            }
+        }
+        // Safety net — `allocateSlots` is supposed to return exactly slotCount,
+        // but guard against rounding edge cases.
+        while working.count < slotCount {
+            working.append(palette.dominant ?? PaletteColor(r: 0, g: 0, b: 0))
+        }
+        working = Array(working.prefix(slotCount))
+
+        // 4. Spatial ordering: OKLCH L descending into rows; within each row,
+        //    OKLCH C ascending. Same shape as before — only the input differs.
+        working.sort { $0.oklch.l > $1.oklch.l }
+
+        let n = gridSize.width
+        var arranged: [PaletteColor] = []
+        arranged.reserveCapacity(slotCount)
+        for row in 0..<n {
+            let rowStart = row * n
+            let rowEnd = rowStart + n
+            var rowSlice = Array(working[rowStart..<rowEnd])
+            rowSlice.sort { $0.oklch.c < $1.oklch.c }
+            arranged.append(contentsOf: rowSlice)
+        }
+        return arranged
+    }
+
+    /// Largest-remainder method: allocate `slotCount` slots across the palette
+    /// proportional to each color's `population`. Returns `(color, count)`
+    /// pairs in palette order (population-descending). Colors with zero
+    /// allocation are omitted.
+    private static func allocateSlots(
+        palette: Palette, slotCount: Int
+    ) -> [(PaletteColor, Int)] {
+        let totalPopulation = palette.colors.reduce(0) { $0 + $1.population }
+        // Defensive: if all populations are 0, fall back to equal distribution
+        // across the prefix of palette.colors.
+        guard totalPopulation > 0 else {
+            var result: [(PaletteColor, Int)] = []
+            let prefix = palette.colors.prefix(slotCount)
+            for c in prefix {
+                result.append((c, 1))
+            }
+            // Pad remaining slots with the first color if palette is shorter
+            // than slotCount.
+            let assigned = result.reduce(0) { $0 + $1.1 }
+            if assigned < slotCount, let first = palette.colors.first {
+                result.append((first, slotCount - assigned))
+            }
+            return result
+        }
+
+        struct Bucket {
+            let color: PaletteColor
+            let exact: Double
+            let floorCount: Int
+        }
+        let buckets: [Bucket] = palette.colors.map { color in
+            let exact = Double(color.population) / Double(totalPopulation) * Double(slotCount)
+            return Bucket(color: color, exact: exact, floorCount: Int(exact.rounded(.down)))
+        }
+        let floorSum = buckets.reduce(0) { $0 + $1.floorCount }
+        let leftover = slotCount - floorSum
+
+        // Indices of the top `leftover` buckets by fractional remainder.
+        let remainders = buckets.enumerated()
+            .map { ($0.offset, $0.element.exact - Double($0.element.floorCount)) }
+            .sorted { $0.1 > $1.1 }
+            .prefix(max(leftover, 0))
+            .map { $0.0 }
+        let bonus = Set(remainders)
+
+        var result: [(PaletteColor, Int)] = []
+        for (idx, b) in buckets.enumerated() {
+            let count = b.floorCount + (bonus.contains(idx) ? 1 : 0)
+            if count > 0 {
+                result.append((b.color, count))
+            }
+        }
+        return result
+    }
+}
+#endif

--- a/Tests/PaletteKitBenchmarks/PaletteMeshGraphicBenchmarks.swift
+++ b/Tests/PaletteKitBenchmarks/PaletteMeshGraphicBenchmarks.swift
@@ -1,0 +1,67 @@
+#if canImport(UIKit)
+import XCTest
+@testable import PaletteKit
+
+@available(iOS 18.0, *)
+final class PaletteMeshGraphicBenchmarks: XCTestCase {
+    private let palette: Palette = {
+        let colors: [PaletteColor] = (0..<32).map { i in
+            let r = UInt8((i * 7) & 0xFF)
+            let g = UInt8((i * 13) & 0xFF)
+            let b = UInt8((i * 23) & 0xFF)
+            return PaletteColor(r: r, g: g, b: b)
+        }
+        return Palette(colors: colors, colorSpaceUsed: .oklch)
+    }()
+
+    @MainActor
+    func test_bench_makeImage_1080_compact() {
+        let view = PaletteMeshGraphic(
+            palette: palette,
+            configuration: .init(gridSize: .compact)
+        )
+        measure {
+            _ = view.makeImage(size: CGSize(width: 1080, height: 1080))
+        }
+    }
+
+    @MainActor
+    func test_bench_makeImage_1080_standard() {
+        let view = PaletteMeshGraphic(palette: palette)
+        measure {
+            _ = view.makeImage(size: CGSize(width: 1080, height: 1080))
+        }
+    }
+
+    @MainActor
+    func test_bench_makeImage_1080_rich() {
+        let view = PaletteMeshGraphic(
+            palette: palette,
+            configuration: .init(gridSize: .rich)
+        )
+        measure {
+            _ = view.makeImage(size: CGSize(width: 1080, height: 1080))
+        }
+    }
+
+    func test_bench_resolveColors_standard() {
+        measure {
+            for _ in 0..<1000 {
+                _ = PaletteMeshGraphicResolver.resolveColors(
+                    palette: palette, gridSize: .standard
+                )
+            }
+        }
+    }
+
+    func test_bench_resolvePoints_rich() {
+        measure {
+            for _ in 0..<10_000 {
+                _ = PaletteMeshGraphicResolver.resolvePoints(
+                    gridSize: .rich, paletteSeed: 42
+                )
+            }
+        }
+    }
+}
+#endif

--- a/Tests/PaletteKitTests/AsyncPaletteGraphicLoaderTests.swift
+++ b/Tests/PaletteKitTests/AsyncPaletteGraphicLoaderTests.swift
@@ -198,6 +198,7 @@ struct AsyncPaletteGraphicLoaderTests {
 import SwiftUI
 
 @Suite("AsyncPaletteGraphic smoke")
+@MainActor
 struct AsyncPaletteGraphicSmokeTests {
     @Test("can instantiate with default-placeholder convenience init")
     func defaultInit() throws {

--- a/Tests/PaletteKitTests/PaletteMeshGraphicConfigurationTests.swift
+++ b/Tests/PaletteKitTests/PaletteMeshGraphicConfigurationTests.swift
@@ -1,0 +1,62 @@
+#if canImport(SwiftUI) && canImport(UIKit)
+import Testing
+@testable import PaletteKit
+
+@Suite("PaletteMeshGraphic.GridSize")
+struct PaletteMeshGraphicGridSizeTests {
+    @Test("GridSize.compact has 2x2 dimensions and 4 colors")
+    @available(iOS 18.0, *)
+    func compact() {
+        let s = PaletteMeshGraphic.GridSize.compact
+        #expect(s.width == 2)
+        #expect(s.height == 2)
+        #expect(s.colorCount == 4)
+    }
+
+    @Test("GridSize.standard has 3x3 dimensions and 9 colors")
+    @available(iOS 18.0, *)
+    func standard() {
+        let s = PaletteMeshGraphic.GridSize.standard
+        #expect(s.width == 3)
+        #expect(s.height == 3)
+        #expect(s.colorCount == 9)
+    }
+
+    @Test("GridSize.rich has 4x4 dimensions and 16 colors")
+    @available(iOS 18.0, *)
+    func rich() {
+        let s = PaletteMeshGraphic.GridSize.rich
+        #expect(s.width == 4)
+        #expect(s.height == 4)
+        #expect(s.colorCount == 16)
+    }
+}
+
+@Suite("PaletteMeshGraphic.Configuration")
+struct PaletteMeshGraphicConfigurationTests {
+    @Test("default Configuration uses standard grid")
+    @available(iOS 18.0, *)
+    func defaults() {
+        let c = PaletteMeshGraphic.Configuration()
+        #expect(c.gridSize == .standard)
+    }
+
+    @Test("Configuration is Equatable")
+    @available(iOS 18.0, *)
+    func equality() {
+        let a = PaletteMeshGraphic.Configuration(gridSize: .compact)
+        let b = PaletteMeshGraphic.Configuration(gridSize: .compact)
+        let c = PaletteMeshGraphic.Configuration(gridSize: .standard)
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test("Configuration is Hashable")
+    @available(iOS 18.0, *)
+    func hashable() {
+        let a = PaletteMeshGraphic.Configuration(gridSize: .compact)
+        let b = PaletteMeshGraphic.Configuration(gridSize: .compact)
+        #expect(a.hashValue == b.hashValue)
+    }
+}
+#endif

--- a/Tests/PaletteKitTests/PaletteMeshGraphicResolverTests.swift
+++ b/Tests/PaletteKitTests/PaletteMeshGraphicResolverTests.swift
@@ -1,0 +1,323 @@
+#if canImport(UIKit)
+import Testing
+@testable import PaletteKit
+
+@Suite("PaletteMeshGraphicResolver.SplitMix64")
+struct PaletteMeshGraphic_SplitMix64Tests {
+    @Test("same seed yields identical sequences")
+    @available(iOS 18.0, *)
+    func deterministic() {
+        var a = PaletteMeshGraphicResolver.SplitMix64(seed: 0xDEAD_BEEF)
+        var b = PaletteMeshGraphicResolver.SplitMix64(seed: 0xDEAD_BEEF)
+        for _ in 0..<8 {
+            #expect(a.next() == b.next())
+        }
+    }
+
+    @Test("different seeds diverge")
+    @available(iOS 18.0, *)
+    func divergence() {
+        var a = PaletteMeshGraphicResolver.SplitMix64(seed: 1)
+        var b = PaletteMeshGraphicResolver.SplitMix64(seed: 2)
+        #expect(a.next() != b.next())
+    }
+
+    @Test("nextDouble returns values in [-1, 1)")
+    @available(iOS 18.0, *)
+    func doubleRange() {
+        var rng = PaletteMeshGraphicResolver.SplitMix64(seed: 42)
+        for _ in 0..<64 {
+            let v = rng.nextDouble()
+            #expect(v >= -1.0)
+            #expect(v < 1.0)
+        }
+    }
+}
+
+@Suite("PaletteMeshGraphicResolver.paletteSeed")
+struct PaletteMeshGraphic_PaletteSeedTests {
+    private let paletteA = Palette(
+        colors: [
+            PaletteColor(r: 200, g: 80, b: 40),
+            PaletteColor(r: 70, g: 50, b: 35)
+        ],
+        colorSpaceUsed: .oklch
+    )
+
+    private let paletteB = Palette(
+        colors: [
+            PaletteColor(r: 10, g: 200, b: 30),
+            PaletteColor(r: 50, g: 60, b: 70)
+        ],
+        colorSpaceUsed: .oklch
+    )
+
+    @Test("same palette yields the same seed across calls")
+    @available(iOS 18.0, *)
+    func stable() {
+        let s1 = PaletteMeshGraphicResolver.paletteSeed(palette: paletteA)
+        let s2 = PaletteMeshGraphicResolver.paletteSeed(palette: paletteA)
+        #expect(s1 == s2)
+    }
+
+    @Test("different palettes produce different seeds")
+    @available(iOS 18.0, *)
+    func divergence() {
+        let s1 = PaletteMeshGraphicResolver.paletteSeed(palette: paletteA)
+        let s2 = PaletteMeshGraphicResolver.paletteSeed(palette: paletteB)
+        #expect(s1 != s2)
+    }
+
+    @Test("empty palette produces a stable, non-trapping seed")
+    @available(iOS 18.0, *)
+    func empty() {
+        let empty = Palette(colors: [], colorSpaceUsed: .oklch)
+        let s = PaletteMeshGraphicResolver.paletteSeed(palette: empty)
+        // Just exercising the path; any UInt64 is fine as long as we don't crash.
+        _ = s
+    }
+}
+
+@Suite("PaletteMeshGraphicResolver.resolvePoints")
+struct PaletteMeshGraphic_ResolvePointsTests {
+    @Test("aligned base grid for .compact (2x2): all corners, no jitter")
+    @available(iOS 18.0, *)
+    func compactCornersOnly() {
+        let pts = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: .compact, paletteSeed: 1
+        )
+        let expected: [SIMD2<Float>] = [[0, 0], [1, 0], [0, 1], [1, 1]]
+        for (i, p) in pts.enumerated() {
+            #expect(abs(p.x - expected[i].x) < 1e-6)
+            #expect(abs(p.y - expected[i].y) < 1e-6)
+        }
+    }
+
+    @Test("corner points remain fixed (standard)")
+    @available(iOS 18.0, *)
+    func cornersFixed() {
+        let pts = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: .standard, paletteSeed: 0xC0FFEE
+        )
+        let corners: [(Int, SIMD2<Float>)] = [
+            (0, [0, 0]), (2, [1, 0]), (6, [0, 1]), (8, [1, 1])
+        ]
+        for (idx, expected) in corners {
+            #expect(abs(pts[idx].x - expected.x) < 1e-6)
+            #expect(abs(pts[idx].y - expected.y) < 1e-6)
+        }
+    }
+
+    @Test("top/bottom edge points keep y at the frame (standard)")
+    @available(iOS 18.0, *)
+    func topBottomEdgeAxisLocked() {
+        let pts = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: .standard, paletteSeed: 0xC0FFEE
+        )
+        #expect(abs(pts[1].y - 0) < 1e-6)
+        #expect(abs(pts[7].y - 1) < 1e-6)
+    }
+
+    @Test("left/right edge points keep x at the frame (standard)")
+    @available(iOS 18.0, *)
+    func leftRightEdgeAxisLocked() {
+        let pts = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: .standard, paletteSeed: 0xC0FFEE
+        )
+        #expect(abs(pts[3].x - 0) < 1e-6)
+        #expect(abs(pts[5].x - 1) < 1e-6)
+    }
+
+    @Test("internal points stay within their own cell bounds (rich)")
+    @available(iOS 18.0, *)
+    func boundedJitter() {
+        let pts = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: .rich, paletteSeed: 0x1234_5678
+        )
+        let n = PaletteMeshGraphic.GridSize.rich.width
+        let denom = Float(n - 1)
+        let cellSize: Float = 1.0 / denom
+        // Same constants as the resolver
+        let maxOffset: Float = 0.3 * 0.49 * cellSize
+        for row in 1..<(n - 1) {
+            for col in 1..<(n - 1) {
+                let baseX = Float(col) / denom
+                let baseY = Float(row) / denom
+                let p = pts[row * n + col]
+                #expect(abs(p.x - baseX) <= maxOffset + 1e-6)
+                #expect(abs(p.y - baseY) <= maxOffset + 1e-6)
+            }
+        }
+    }
+
+    @Test("same seed yields identical points")
+    @available(iOS 18.0, *)
+    func deterministic() {
+        let a = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: .rich, paletteSeed: 99
+        )
+        let b = PaletteMeshGraphicResolver.resolvePoints(
+            gridSize: .rich, paletteSeed: 99
+        )
+        #expect(a == b)
+    }
+}
+
+@Suite("PaletteMeshGraphicResolver.resolveColors")
+struct PaletteMeshGraphic_ResolveColorsTests {
+    private static func palette(_ rgbWithPop: [(UInt8, UInt8, UInt8, Int)]) -> Palette {
+        Palette(
+            colors: rgbWithPop.map { PaletteColor(r: $0.0, g: $0.1, b: $0.2, population: $0.3) },
+            colorSpaceUsed: .oklch
+        )
+    }
+
+    @Test("returns exactly gridSize.colorCount colors for each grid size")
+    @available(iOS 18.0, *)
+    func count() {
+        let p = Self.palette([
+            (200, 80, 40, 100), (150, 110, 90, 80), (70, 50, 35, 50)
+        ])
+        for grid in [PaletteMeshGraphic.GridSize.compact, .standard, .rich] {
+            let colors = PaletteMeshGraphicResolver.resolveColors(
+                palette: p, gridSize: grid
+            )
+            #expect(colors.count == grid.colorCount)
+        }
+    }
+
+    @Test("empty palette returns black slots, never crashes")
+    @available(iOS 18.0, *)
+    func emptyPalette() {
+        let p = Palette(colors: [], colorSpaceUsed: .oklch)
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: p, gridSize: .standard
+        )
+        #expect(colors.count == 9)
+        #expect(colors.allSatisfy { $0.rgb == RGB(r: 0, g: 0, b: 0) })
+    }
+
+    @Test("dominant color claims more slots than minor colors")
+    @available(iOS 18.0, *)
+    func dominantClaimsMore() {
+        // A clearly takes ~80%, B ~15%, C ~5%
+        let p = Self.palette([
+            (220, 30, 30, 800),
+            (30, 220, 30, 150),
+            (30, 30, 220, 50),
+        ])
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: p, gridSize: .standard
+        )
+        let countA = colors.filter { $0.rgb.r == 220 }.count
+        let countB = colors.filter { $0.rgb.g == 220 }.count
+        let countC = colors.filter { $0.rgb.b == 220 }.count
+        #expect(countA > countB)
+        #expect(countB >= countC)
+        #expect(countA + countB + countC == 9)
+    }
+
+    @Test("a color with negligible population is dropped from the mesh")
+    @available(iOS 18.0, *)
+    func negligibleColorDropped() {
+        // 99 % A, 1 % B in a 9-slot mesh → B should get 0 slots
+        // (1% of 9 = 0.09, floor = 0; largest-remainder pass might assign it 0 or 1
+        //  depending on other remainders. Use stronger numbers to force the drop.)
+        let p = Self.palette([
+            (220, 30, 30, 990),   // 99.0%
+            (30, 220, 30, 10),    // 1.0%
+        ])
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: p, gridSize: .standard
+        )
+        let countB = colors.filter { $0.rgb.g == 220 }.count
+        #expect(countB == 0, "expected the 1% color to be dropped, got \(countB) slots")
+    }
+
+    @Test("uniform palette (all populations equal) distributes evenly")
+    @available(iOS 18.0, *)
+    func uniformDistribution() {
+        let p = Self.palette([
+            (220, 30, 30, 100),
+            (30, 220, 30, 100),
+            (30, 30, 220, 100),
+        ])
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: p, gridSize: .standard
+        )
+        let countA = colors.filter { $0.rgb.r == 220 }.count
+        let countB = colors.filter { $0.rgb.g == 220 }.count
+        let countC = colors.filter { $0.rgb.b == 220 }.count
+        // 9 slots / 3 colors = 3 each
+        #expect(countA == 3)
+        #expect(countB == 3)
+        #expect(countC == 3)
+    }
+
+    @Test("zero-population palette falls back to equal distribution from the prefix")
+    @available(iOS 18.0, *)
+    func zeroPopulationFallback() {
+        // No population data — every color is population 0.
+        let p = Self.palette([
+            (220, 30, 30, 0),
+            (30, 220, 30, 0),
+            (30, 30, 220, 0),
+        ])
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: p, gridSize: .standard
+        )
+        #expect(colors.count == 9)
+        // Each of the three palette colors should appear at least once.
+        let rgbs = Set(colors.map(\.rgb))
+        #expect(rgbs.contains(RGB(r: 220, g: 30, b: 30)))
+        #expect(rgbs.contains(RGB(r: 30, g: 220, b: 30)))
+        #expect(rgbs.contains(RGB(r: 30, g: 30, b: 220)))
+    }
+
+    @Test("rows sorted by OKLCH luminance (top brighter than bottom)")
+    @available(iOS 18.0, *)
+    func luminanceSortRows() {
+        let p = Self.palette([
+            (240, 240, 240, 100), (220, 220, 220, 100), (200, 200, 200, 100),
+            (160, 160, 160, 100), (120, 120, 120, 100), (100, 100, 100, 100),
+            (60, 60, 60, 100),    (40, 40, 40, 100),    (20, 20, 20, 100),
+        ])
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: p, gridSize: .standard
+        )
+        func rowAvgL(_ row: Int) -> Double {
+            let n = 3
+            return (0..<n).map { colors[row * n + $0].oklch.l }.reduce(0, +) / Double(n)
+        }
+        #expect(rowAvgL(0) >= rowAvgL(1))
+        #expect(rowAvgL(1) >= rowAvgL(2))
+    }
+
+    @Test("within a row, chroma increases left to right")
+    @available(iOS 18.0, *)
+    func chromaSortColumns() {
+        let p = Self.palette([
+            (200, 200, 200, 100),
+            (255, 100, 100, 100),
+            (100, 255, 100, 100),
+            (160, 160, 160, 100),
+            (255, 50, 50, 100),
+            (50, 255, 50, 100),
+            (100, 100, 100, 100),
+            (200, 0, 0, 100),
+            (0, 200, 0, 100),
+        ])
+        let colors = PaletteMeshGraphicResolver.resolveColors(
+            palette: p, gridSize: .standard
+        )
+        let n = 3
+        for row in 0..<n {
+            let rowColors = (0..<n).map { colors[row * n + $0] }
+            for i in 1..<rowColors.count {
+                #expect(rowColors[i].oklch.c >= rowColors[i - 1].oklch.c,
+                        "chroma not non-decreasing at row \(row), col \(i)")
+            }
+        }
+    }
+}
+#endif

--- a/Tests/PaletteKitTests/PaletteMeshGraphicTests.swift
+++ b/Tests/PaletteKitTests/PaletteMeshGraphicTests.swift
@@ -1,0 +1,99 @@
+#if canImport(SwiftUI) && canImport(UIKit)
+import Testing
+import SwiftUI
+@testable import PaletteKit
+
+@Suite("PaletteMeshGraphic (view)")
+struct PaletteMeshGraphicViewTests {
+    private let palette = Palette(
+        colors: [
+            PaletteColor(r: 240, g: 100, b: 100),
+            PaletteColor(r: 100, g: 240, b: 100),
+            PaletteColor(r: 100, g: 100, b: 240),
+            PaletteColor(r: 230, g: 230, b: 30),
+            PaletteColor(r: 30, g: 230, b: 230),
+            PaletteColor(r: 230, g: 30, b: 230),
+            PaletteColor(r: 240, g: 240, b: 240),
+            PaletteColor(r: 120, g: 120, b: 120),
+            PaletteColor(r: 20, g: 20, b: 20),
+        ],
+        colorSpaceUsed: .oklch
+    )
+
+    @Test("stores palette, configuration as passed")
+    @available(iOS 18.0, *)
+    func initStoresInputs() {
+        let cfg = PaletteMeshGraphic.Configuration(gridSize: .rich)
+        let view = PaletteMeshGraphic(palette: palette, configuration: cfg)
+        #expect(view.palette.colors.count == 9)
+        #expect(view.configuration == cfg)
+    }
+
+    @Test("makeImage returns a non-nil image at a reasonable size")
+    @MainActor
+    @available(iOS 18.0, *)
+    func makeImageReturnsImage() {
+        let view = PaletteMeshGraphic(palette: palette)
+        let image = view.makeImage(size: CGSize(width: 64, height: 64))
+        #expect(image != nil)
+        #expect((image?.size.width ?? 0) > 0)
+    }
+
+    @Test("makeImage returns nil for zero size")
+    @MainActor
+    @available(iOS 18.0, *)
+    func makeImageNilForZeroSize() {
+        let view = PaletteMeshGraphic(palette: palette)
+        #expect(view.makeImage(size: .zero) == nil)
+        #expect(view.makeImage(size: CGSize(width: 64, height: 0)) == nil)
+        #expect(view.makeImage(size: CGSize(width: 0, height: 64)) == nil)
+    }
+
+    @Test("makeImage returns nil for zero scale")
+    @MainActor
+    @available(iOS 18.0, *)
+    func makeImageNilForZeroScale() {
+        let view = PaletteMeshGraphic(palette: palette)
+        #expect(view.makeImage(size: CGSize(width: 64, height: 64), scale: 0) == nil)
+    }
+
+    @Test("makeImage scale is reflected in the resulting UIImage")
+    @MainActor
+    @available(iOS 18.0, *)
+    func makeImageRespectsScale() {
+        let view = PaletteMeshGraphic(palette: palette)
+        let img = view.makeImage(size: CGSize(width: 32, height: 32), scale: 3)
+        #expect(abs((img?.scale ?? 0) - 3.0) < 1e-6)
+    }
+
+    @Test("makeImage is deterministic for identical inputs")
+    @MainActor
+    @available(iOS 18.0, *)
+    func makeImageDeterministic() {
+        let view = PaletteMeshGraphic(palette: palette)
+        let img1 = view.makeImage(size: CGSize(width: 96, height: 96))
+        let img2 = view.makeImage(size: CGSize(width: 96, height: 96))
+        #expect(img1 != nil)
+        #expect(img2 != nil)
+        let png1 = img1?.pngData()
+        let png2 = img2?.pngData()
+        #expect(png1 != nil)
+        #expect(png2 != nil)
+        #expect(png1 == png2)
+    }
+
+    @Test("renders for all grid sizes without crashing")
+    @MainActor
+    @available(iOS 18.0, *)
+    func rendersAllGrids() {
+        for grid in [PaletteMeshGraphic.GridSize.compact, .standard, .rich] {
+            let view = PaletteMeshGraphic(
+                palette: palette,
+                configuration: .init(gridSize: grid)
+            )
+            let img = view.makeImage(size: CGSize(width: 48, height: 48))
+            #expect(img != nil, "grid \(grid) returned nil")
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `PaletteMeshGraphic`, a SwiftUI mesh gradient primitive on top of iOS 18+ `MeshGradient`. Sibling to `PaletteGraphic` with the same call shape.
- Color slots are allocated proportional to each palette color's `population` so the mesh inherits the source photo's dominance distribution.
- Ships with a DocC tutorial section, demo app tab, benchmark suite, and CHANGELOG entry.

## Test plan
- [x] macOS host: `swift test --filter PaletteKitTests` — 35/35 baseline pass
- [x] iOS 18 simulator (iPhone 17 Pro): all PaletteKitTests pass (118/118)
- [x] Demo app builds for iOS 18+ simulator
- [x] DocC builds with no new warnings on PaletteMeshGraphic symbols
- [x] iOS 17 simulator build (verifies `@available(iOS 18.0, *)` gating compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)