### PR TITLE
feat: AnimatedPaletteGraphic — animated "living gradient" (v2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to PaletteKit are documented here.
 
+## 2.0.0
+
+### Added
+- `AnimatedPaletteGraphic` (SwiftUI) and `AnimatedPaletteGraphicView` (UIKit)
+  — an animated "living gradient" that renders a `Palette` as a multi-point,
+  LAB-blended flow with organic, non-periodic (spring-driven) motion.
+  - `Configuration`: `colorCount` (`.two`…`.five`), `speed`
+    (`FlowSpeed`: `.slow` / `.regular` / `.fast`), `isAnimated`.
+  - Honors Reduce Motion and Low Power Mode (holds a static frame) and
+    pauses while off-screen.
+  - SwiftUI and UIKit share one inline-source Metal renderer (no `.metallib`
+    resource bundle); the SwiftUI view wraps the UIKit view.
+
+### Changed
+- `ColorCount` moved to its own file so it is shared by `PaletteGraphic` and
+  `AnimatedPaletteGraphic`. No API change.
+
 ## 1.7.0
 
 ### Added

--- a/Examples/PaletteKitDemo/PaletteKitDemo/Card/AnimatedLabView.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/Card/AnimatedLabView.swift
@@ -1,0 +1,58 @@
+import PaletteKit
+import SwiftUI
+
+/// Playground for ``AnimatedPaletteGraphic`` — tweak color count, speed, and the
+/// animated toggle on the extracted palette.
+struct AnimatedLabView: View {
+    let palette: Palette
+
+    @State private var colorCount: ColorCount = .three
+    @State private var speed: FlowSpeed = .regular
+    @State private var isAnimated = true
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                AnimatedPaletteGraphic(
+                    palette: palette,
+                    configuration: .init(
+                        colorCount: colorCount,
+                        speed: speed,
+                        isAnimated: isAnimated
+                    )
+                )
+                .frame(height: 320)
+                .clipShape(RoundedRectangle(cornerRadius: 24))
+                .padding(.horizontal)
+
+                colorCountPicker
+                speedPicker
+                Toggle("Animated", isOn: $isAnimated)
+                    .padding(.horizontal)
+            }
+            .padding(.vertical)
+        }
+        .navigationTitle("Animated")
+    }
+
+    private var colorCountPicker: some View {
+        Picker("Colors", selection: $colorCount) {
+            Text("2").tag(ColorCount.two)
+            Text("3").tag(ColorCount.three)
+            Text("4").tag(ColorCount.four)
+            Text("5").tag(ColorCount.five)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+    }
+
+    private var speedPicker: some View {
+        Picker("Speed", selection: $speed) {
+            Text("Slow").tag(FlowSpeed.slow)
+            Text("Regular").tag(FlowSpeed.regular)
+            Text("Fast").tag(FlowSpeed.fast)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal)
+    }
+}

--- a/Examples/PaletteKitDemo/PaletteKitDemo/ContentView.swift
+++ b/Examples/PaletteKitDemo/PaletteKitDemo/ContentView.swift
@@ -123,6 +123,10 @@ struct ContentView: View {
                 if #available(iOS 18.0, *), let palette, !palette.isEmpty {
                     meshEntry(palette: palette)
                 }
+
+                if let palette, !palette.isEmpty {
+                    animatedEntry(palette: palette)
+                }
             }
         }
     }
@@ -146,6 +150,25 @@ struct ContentView: View {
         .buttonStyle(.plain)
     }
 
+    @ViewBuilder
+    private func animatedEntry(palette: Palette) -> some View {
+        NavigationLink {
+            AnimatedLabView(palette: palette)
+        } label: {
+            HStack {
+                Image(systemName: "sparkles")
+                Text("Animate Graphic")
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding()
+            .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+
     @available(iOS 18.0, *)
     @ViewBuilder
     private func meshEntry(palette: Palette) -> some View {
@@ -154,7 +177,7 @@ struct ContentView: View {
         } label: {
             HStack {
                 Image(systemName: "circle.grid.3x3.fill")
-                Text("Generate Mesh")
+                Text("Generate Mesh Graphic")
                 Spacer()
                 Image(systemName: "chevron.right")
                     .font(.footnote)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ UIKit pair: `AsyncPaletteGraphicView`. Both share a process-wide
 asynchronously](https://swiftpackageindex.com/2dubu/palettekit/main/documentation/palettekit/asyncloading)
 for caching, transitions, and error handling.
 
+### Animate a graphic
+
+`AnimatedPaletteGraphic` renders the palette as a slowly morphing "living
+gradient" — a multi-point, LAB-blended flow with organic, non-periodic motion.
+It fills its frame; clip to any shape.
+
+```swift
+AnimatedPaletteGraphic(
+    palette: palette,
+    configuration: .init(
+        colorCount: .three,   // .two ... .five
+        speed: .regular,      // .slow / .regular / .fast
+        isAnimated: true
+    )
+)
+.frame(width: 320, height: 420)
+.clipShape(RoundedRectangle(cornerRadius: 24))
+```
+
+UIKit pair: `AnimatedPaletteGraphicView`. Both honor Reduce Motion and Low
+Power Mode (hold a static frame) and pause while off-screen.
+
 ## Features
 
 - **Async, Sendable, Swift 6 strict concurrency.** Every entry point is
@@ -290,7 +312,7 @@ don't need to run it.
 - **v1.5** ✅ shipped — `AsyncPaletteGraphic` + `AsyncPaletteGraphicView` async-loading wrappers with `PaletteCache`.
 - **v1.6** ✅ shipped — `PaletteMeshGraphic` (iOS 18+ multi-color mesh primitive on top of SwiftUI's native `MeshGradient`).
 - **v1.7** ✅ shipped — `SwatchMap` ergonomics (`color/titleTextColor/bodyTextColor(for:fallback:)` on both `SwatchMap` and `Optional<SwatchMap>`).
-- **v2.0** — `observe()`: live video / camera frame stream → `AsyncStream<Palette>`.
+- **v2.0** ✅ shipped — `AnimatedPaletteGraphic` + `AnimatedPaletteGraphicView`: animated, LAB-blended "living gradient" from an extracted palette.
 - **v2.1** — `PaletteKitInsights`: FoundationModels captions, color naming, custom instructions on iOS 26+ (separate optional module).
 
 Per-release notes live on [GitHub Releases](https://github.com/2dubu/PaletteKit/releases).

--- a/Sources/PaletteKit/ColorSpace/LABConversion.swift
+++ b/Sources/PaletteKit/ColorSpace/LABConversion.swift
@@ -1,0 +1,39 @@
+import Foundation
+import simd
+
+/// Internal CIE LAB (D65) conversion. LAB blending avoids the muddy mid-tones
+/// that sRGB averaging produces between complementary colors.
+enum LABConversion {
+    /// sRGB (8-bit) → CIE LAB (D65). `x` = L, `y` = a, `z` = b.
+    static func rgbToLAB(_ rgb: RGB) -> SIMD3<Float> {
+        func toLinear(_ c: Double) -> Double {
+            c > 0.04045 ? pow((c + 0.055) / 1.055, 2.4) : c / 12.92
+        }
+        let r = toLinear(Double(rgb.r) / 255)
+        let g = toLinear(Double(rgb.g) / 255)
+        let b = toLinear(Double(rgb.b) / 255)
+        let x = (r * 0.4124 + g * 0.3576 + b * 0.1805) * 100
+        let y = (r * 0.2126 + g * 0.7152 + b * 0.0722) * 100
+        let z = (r * 0.0193 + g * 0.1192 + b * 0.9505) * 100
+        func f(_ t: Double) -> Double { t > 0.008856 ? pow(t, 1.0 / 3.0) : (7.787 * t + 16.0 / 116.0) }
+        let fx = f(x / 95.047), fy = f(y / 100.0), fz = f(z / 108.883)
+        return SIMD3(Float(116 * fy - 16), Float(500 * (fx - fy)), Float(200 * (fy - fz)))
+    }
+
+    /// CIE LAB (D65) → sRGB (8-bit), clamped.
+    static func labToRGB(_ lab: SIMD3<Float>) -> RGB {
+        let l = Double(lab.x), a = Double(lab.y), bb = Double(lab.z)
+        let fy = (l + 16) / 116, fx = a / 500 + fy, fz = fy - bb / 200
+        func inv(_ t: Double) -> Double {
+            let t3 = t * t * t
+            return t3 > 0.008856 ? t3 : (t - 16.0 / 116.0) / 7.787
+        }
+        let x = 95.047 * inv(fx) / 100, y = 100.0 * inv(fy) / 100, z = 108.883 * inv(fz) / 100
+        func toSRGB(_ c: Double) -> Double { c > 0.0031308 ? 1.055 * pow(c, 1 / 2.4) - 0.055 : 12.92 * c }
+        let r = toSRGB(x * 3.2406 + y * -1.5372 + z * -0.4986)
+        let g = toSRGB(x * -0.9689 + y * 1.8758 + z * 0.0415)
+        let b = toSRGB(x * 0.0557 + y * -0.2040 + z * 1.0570)
+        func u8(_ v: Double) -> UInt8 { UInt8(max(0, min(255, (v * 255).rounded()))) }
+        return RGB(r: u8(r), g: u8(g), b: u8(b))
+    }
+}

--- a/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteFlowRenderer.swift
+++ b/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteFlowRenderer.swift
@@ -1,0 +1,96 @@
+#if canImport(UIKit)
+import MetalKit
+import simd
+
+private let kFlowSlots = AnimatedPaletteFlowShader.slots
+
+/// Mirror of the Metal `FlowUniforms` layout. File-scope (not nested in a
+/// @MainActor type) so the nonisolated renderer can build it.
+private struct FlowUniforms {
+    var count: Int32 = 0
+    var bias: Float = 0.01
+    var power: Float = 4
+    var pad: Float = 0
+    var points: (SIMD2<Float>, SIMD2<Float>, SIMD2<Float>, SIMD2<Float>,
+                 SIMD2<Float>, SIMD2<Float>, SIMD2<Float>, SIMD2<Float>) =
+        (.zero, .zero, .zero, .zero, .zero, .zero, .zero, .zero)
+    var colors: (SIMD4<Float>, SIMD4<Float>, SIMD4<Float>, SIMD4<Float>,
+                 SIMD4<Float>, SIMD4<Float>, SIMD4<Float>, SIMD4<Float>) =
+        (.zero, .zero, .zero, .zero, .zero, .zero, .zero, .zero)
+}
+
+/// Drives the Metal pipeline + per-frame draw for ``AnimatedPaletteGraphicView``.
+/// Not `@MainActor`: `MTKViewDelegate` requirements are nonisolated, and all
+/// access happens on the main thread (view updates + MTKView's main-loop calls).
+final class AnimatedPaletteFlowRenderer: NSObject, MTKViewDelegate {
+    private var pipeline: MTLRenderPipelineState?
+    private var queue: MTLCommandQueue?
+    private var motion: FlowMotion?
+    private var colors: [SIMD4<Float>] = []   // xyz = LAB
+    private var count = 0
+    private var speed: Float = 0.2
+    private var frozen = false
+    private var lastTime = CACurrentMediaTime()
+
+    @MainActor
+    func configure(view: MTKView) {
+        guard let device = view.device,
+              let library = try? device.makeLibrary(source: AnimatedPaletteFlowShader.source, options: nil)
+        else { return }
+        let desc = MTLRenderPipelineDescriptor()
+        desc.vertexFunction = library.makeFunction(name: "paletteFlowVertex")
+        desc.fragmentFunction = library.makeFunction(name: "paletteFlowFragment")
+        desc.colorAttachments[0].pixelFormat = view.colorPixelFormat
+        pipeline = try? device.makeRenderPipelineState(descriptor: desc)
+        queue = device.makeCommandQueue()
+    }
+
+    /// `labColors` are CIE LAB vectors (see ``LABConversion``).
+    func update(labColors: [SIMD3<Float>], speed: Float, frozen: Bool) {
+        let n = min(kFlowSlots, max(1, labColors.count))
+        if n != count || motion == nil {
+            count = n
+            motion = FlowMotion(count: n)
+        }
+        colors = (0..<n).map { SIMD4(labColors[$0].x, labColors[$0].y, labColors[$0].z, 1) }
+        self.speed = speed
+        self.frozen = frozen
+    }
+
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
+
+    func draw(in view: MTKView) {
+        guard let pipeline, let queue, let motion,
+              let rpd = view.currentRenderPassDescriptor,
+              let drawable = view.currentDrawable,
+              let buffer = queue.makeCommandBuffer(),
+              let enc = buffer.makeRenderCommandEncoder(descriptor: rpd) else { return }
+
+        let now = CACurrentMediaTime()
+        let dt = Float(now - lastTime)
+        lastTime = now
+        if !frozen { motion.advance(dt: dt, speed: speed) }
+        let pos = motion.positions
+
+        var u = FlowUniforms()
+        u.count = Int32(count)
+        u.power = AnimatedPaletteGraphic.Configuration.power
+        withUnsafeMutablePointer(to: &u.points) { ptr in
+            ptr.withMemoryRebound(to: SIMD2<Float>.self, capacity: kFlowSlots) { dst in
+                for i in 0..<count { dst[i] = pos[i] }
+            }
+        }
+        withUnsafeMutablePointer(to: &u.colors) { ptr in
+            ptr.withMemoryRebound(to: SIMD4<Float>.self, capacity: kFlowSlots) { dst in
+                for i in 0..<count { dst[i] = colors[i] }
+            }
+        }
+        enc.setRenderPipelineState(pipeline)
+        enc.setFragmentBytes(&u, length: MemoryLayout<FlowUniforms>.stride, index: 0)
+        enc.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
+        enc.endEncoding()
+        buffer.present(drawable)
+        buffer.commit()
+    }
+}
+#endif

--- a/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteFlowShader.swift
+++ b/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteFlowShader.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Inline Metal source for the animated palette gradient, compiled at runtime via
+/// `device.makeLibrary(source:)` — no `.metal` resource / metallib bundle (matches
+/// ``MetalContext`` and ColorfulX). Multi-point inverse-distance blend in LAB.
+enum AnimatedPaletteFlowShader {
+    /// Maximum number of color points the uniforms carry.
+    static let slots = 8
+
+    static let source = """
+    #include <metal_stdlib>
+    using namespace metal;
+
+    struct VOut { float4 pos [[position]]; float2 uv; };
+
+    vertex VOut paletteFlowVertex(uint vid [[vertex_id]]) {
+        float2 p = float2((vid << 1) & 2, vid & 2);
+        VOut o;
+        o.pos = float4(p * 2.0 - 1.0, 0, 1);
+        o.uv = float2(p.x, 1.0 - p.y);
+        return o;
+    }
+
+    struct FlowUniforms {
+        int count;
+        float bias;
+        float power;
+        float pad;
+        float2 points[8];
+        float4 colors[8];   // xyz = CIE LAB
+    };
+
+    static float3 lab2xyz(float3 lab) {
+        float y = (lab.x + 16.0) / 116.0;
+        float x = lab.y / 500.0 + y;
+        float z = y - lab.z / 200.0;
+        float3 v = float3(x, y, z);
+        float3 v3 = v * v * v;
+        float3 xyz = select((v - 16.0 / 116.0) / 7.787, v3, v3 > 0.008856);
+        return xyz * float3(95.047, 100.0, 108.883);
+    }
+    static float3 xyz2rgb(float3 xyz) {
+        float3 t = xyz / 100.0;
+        float3 c = float3(
+            t.x * 3.2406 + t.y * -1.5372 + t.z * -0.4986,
+            t.x * -0.9689 + t.y * 1.8758 + t.z * 0.0415,
+            t.x * 0.0557 + t.y * -0.2040 + t.z * 1.0570);
+        c = select(12.92 * c, 1.055 * pow(c, 1.0 / 2.4) - 0.055, c > 0.0031308);
+        return clamp(c, 0.0, 1.0);
+    }
+    static float3 lab2rgb(float3 lab) { return xyz2rgb(lab2xyz(lab)); }
+
+    fragment float4 paletteFlowFragment(VOut in [[stage_in]], constant FlowUniforms& U [[buffer(0)]]) {
+        float2 uv = in.uv;
+        float total = 0.0;
+        float contrib[8];
+        for (int i = 0; i < U.count; i++) {
+            float dist = length(uv - U.points[i]);
+            float c = 1.0 / (U.bias + pow(dist, U.power));
+            contrib[i] = c;
+            total += c;
+        }
+        float3 lab = float3(0.0);
+        for (int i = 0; i < U.count; i++) {
+            lab += U.colors[i].xyz * (contrib[i] / total);
+        }
+        return float4(lab2rgb(lab), 1.0);
+    }
+    """
+}

--- a/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteGraphic+View.swift
+++ b/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteGraphic+View.swift
@@ -1,0 +1,22 @@
+#if canImport(UIKit)
+import SwiftUI
+
+extension AnimatedPaletteGraphic: View {
+    public var body: some View {
+        Representable(palette: palette, configuration: configuration)
+    }
+
+    private struct Representable: UIViewRepresentable {
+        let palette: Palette
+        let configuration: Configuration
+
+        func makeUIView(context: Context) -> AnimatedPaletteGraphicView {
+            AnimatedPaletteGraphicView(palette: palette, configuration: configuration)
+        }
+
+        func updateUIView(_ view: AnimatedPaletteGraphicView, context: Context) {
+            view.update(palette: palette, configuration: configuration)
+        }
+    }
+}
+#endif

--- a/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteGraphic.swift
+++ b/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteGraphic.swift
@@ -1,0 +1,65 @@
+import Foundation
+import simd
+
+/// A "living gradient": renders an extracted ``Palette`` as a slowly morphing,
+/// LAB-blended, multi-point gradient. Fills its frame — clip to any shape with
+/// `.clipShape`.
+///
+/// ```swift
+/// AnimatedPaletteGraphic(
+///     palette: palette,
+///     configuration: .init(
+///         colorCount: .three,   // .two ... .five
+///         speed: .regular,      // .slow / .regular / .fast
+///         isAnimated: true
+///     )
+/// )
+/// .frame(width: 320, height: 420)
+/// .clipShape(RoundedRectangle(cornerRadius: 24))
+/// ```
+///
+/// On non-UIKit platforms this is a plain value type (no rendering); the SwiftUI
+/// `View` conformance and renderer are provided where UIKit is available.
+public struct AnimatedPaletteGraphic {
+    let palette: Palette
+    let configuration: Configuration
+
+    public init(palette: Palette, configuration: Configuration = .init()) {
+        self.palette = palette
+        self.configuration = configuration
+    }
+}
+
+extension AnimatedPaletteGraphic {
+    /// Tunable parameters for the animated gradient.
+    public struct Configuration: Sendable, Equatable {
+        /// How many of the palette's colors (by population) drive the gradient.
+        public var colorCount: ColorCount
+        /// Flow speed.
+        public var speed: FlowSpeed
+        /// When `false`, the gradient holds a static frame.
+        public var isAnimated: Bool
+
+        public init(
+            colorCount: ColorCount = .three,
+            speed: FlowSpeed = .regular,
+            isAnimated: Bool = true
+        ) {
+            self.colorCount = colorCount
+            self.speed = speed
+            self.isAnimated = isAnimated
+        }
+
+        /// Fixed inverse-distance falloff exponent for the blend (matches
+        /// ColorfulX's default; tuned for the smoothest look in the bake-off).
+        static let power: Float = 4
+
+        /// The chosen palette colors as CIE LAB vectors, padded/repeated to
+        /// `colorCount`. Colors are taken in population order (most prominent
+        /// first), since ``Palette`` is sorted that way.
+        func resolveLABColors(from palette: Palette) -> [SIMD3<Float>] {
+            let source = palette.colors.isEmpty ? [PaletteColor.black] : palette.colors
+            return (0..<colorCount.rawValue).map { LABConversion.rgbToLAB(source[$0 % source.count].rgb) }
+        }
+    }
+}

--- a/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteGraphicView.swift
+++ b/Sources/PaletteKit/Graphic/Animated/AnimatedPaletteGraphicView.swift
@@ -1,0 +1,81 @@
+#if canImport(UIKit)
+import MetalKit
+import UIKit
+
+/// UIKit animated palette gradient. Hosts an `MTKView` and renders a living,
+/// LAB-blended multi-point gradient from a ``Palette``. Fills its bounds — mask
+/// to any shape with `layer.cornerRadius` or a mask layer, like
+/// ``PaletteGraphicView``.
+///
+/// Honors Reduce Motion and Low Power Mode (holds a static frame) and pauses
+/// while off-screen.
+public final class AnimatedPaletteGraphicView: UIView {
+    private let metalView = MTKView()
+    private let renderer = AnimatedPaletteFlowRenderer()
+    private var palette: Palette
+    private var configuration: AnimatedPaletteGraphic.Configuration
+
+    public init(palette: Palette,
+                configuration: AnimatedPaletteGraphic.Configuration = .init()) {
+        self.palette = palette
+        self.configuration = configuration
+        super.init(frame: .zero)
+
+        metalView.device = MTLCreateSystemDefaultDevice()
+        metalView.framebufferOnly = true
+        metalView.enableSetNeedsDisplay = false
+        metalView.isPaused = false
+        metalView.delegate = renderer
+        metalView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(metalView)
+        NSLayoutConstraint.activate([
+            metalView.topAnchor.constraint(equalTo: topAnchor),
+            metalView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            metalView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            metalView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+        renderer.configure(view: metalView)
+        applyConfiguration()
+
+        let center = NotificationCenter.default
+        center.addObserver(self, selector: #selector(refreshMotionState),
+                           name: UIAccessibility.reduceMotionStatusDidChangeNotification, object: nil)
+        center.addObserver(self, selector: #selector(refreshMotionState),
+                           name: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Update the palette and/or configuration after creation.
+    public func update(palette: Palette? = nil,
+                       configuration: AnimatedPaletteGraphic.Configuration? = nil) {
+        if let palette { self.palette = palette }
+        if let configuration { self.configuration = configuration }
+        applyConfiguration()
+    }
+
+    private var shouldFreeze: Bool {
+        !configuration.isAnimated
+            || UIAccessibility.isReduceMotionEnabled
+            || ProcessInfo.processInfo.isLowPowerModeEnabled
+            || window == nil
+            || isHidden
+    }
+
+    private func applyConfiguration() {
+        renderer.update(
+            labColors: configuration.resolveLABColors(from: palette),
+            speed: Float(configuration.speed.multiplier),
+            frozen: shouldFreeze
+        )
+    }
+
+    @objc private func refreshMotionState() { applyConfiguration() }
+
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+        applyConfiguration()   // pause when leaving the hierarchy, resume when re-added
+    }
+}
+#endif

--- a/Sources/PaletteKit/Graphic/Animated/FlowMotion.swift
+++ b/Sources/PaletteKit/Graphic/Animated/FlowMotion.swift
@@ -1,0 +1,59 @@
+import Foundation
+import simd
+
+/// Spring-driven, non-periodic motion for N color points — a port of ColorfulX's
+/// random speckle director: each point springs toward a random target in the unit
+/// square and, once close, picks a new one. No sin/cos, so motion never visibly
+/// repeats. Seedable so layouts are reproducible (and shareable across views).
+///
+/// Not `Sendable`: instances are owned and mutated on the main thread by the
+/// animated graphic views.
+final class FlowMotion {
+    private struct Point { var pos: SIMD2<Float>; var vel: SIMD2<Float>; var target: SIMD2<Float> }
+    private var pts: [Point]
+    private var rng: SplitMix64
+
+    init(count: Int, seed: UInt64 = 0xA11CE) {
+        var g = SplitMix64(seed: seed)
+        pts = (0..<max(1, count)).map { _ in
+            Point(pos: SIMD2(Float(g.unit()), Float(g.unit())),
+                  vel: .zero,
+                  target: SIMD2(Float(g.unit()), Float(g.unit())))
+        }
+        rng = g
+    }
+
+    var positions: [SIMD2<Float>] { pts.map(\.pos) }
+
+    /// Advance by a raw delta (seconds), scaled by `speed`.
+    func advance(dt rawDt: Float, speed: Float) {
+        let dt = min(max(rawDt, 0), 1.0 / 30.0) * max(speed, 0) * 1.6
+        guard dt > 0 else { return }
+        let k: Float = 8.0                 // stiffness
+        let d: Float = 2 * k.squareRoot()  // critical damping
+        for i in pts.indices {
+            var p = pts[i]
+            let accel = -k * (p.pos - p.target) - d * p.vel
+            p.vel += accel * dt
+            p.pos += p.vel * dt
+            if abs(p.pos.x - p.target.x) < 0.12, abs(p.pos.y - p.target.y) < 0.12 {
+                p.target = SIMD2(Float(rng.unit()), Float(rng.unit()))
+            }
+            pts[i] = p
+        }
+    }
+}
+
+/// Tiny deterministic PRNG so seeded layouts are reproducible in tests.
+private struct SplitMix64 {
+    private var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func unit() -> Double {
+        state &+= 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        z ^= (z >> 31)
+        return Double(z >> 11) * (1.0 / 9007199254740992.0)
+    }
+}

--- a/Sources/PaletteKit/Graphic/Animated/FlowSpeed.swift
+++ b/Sources/PaletteKit/Graphic/Animated/FlowSpeed.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Flow speed for ``AnimatedPaletteGraphic`` — Apple-style preset object (cf.
+/// `Animation.snappy`, `Material.regular`): named presets for the common cases
+/// plus a public escape-hatch initializer for fine control.
+public struct FlowSpeed: Sendable, Equatable, Hashable {
+    /// Motion-rate multiplier (0 = still).
+    public let multiplier: Double
+
+    /// Escape hatch for a custom speed. Clamped to `>= 0`.
+    public init(_ multiplier: Double) { self.multiplier = max(0, multiplier) }
+
+    public static let slow = FlowSpeed(0.1)
+    public static let regular = FlowSpeed(0.2)   // baseline
+    public static let fast = FlowSpeed(0.3)
+}

--- a/Sources/PaletteKit/Graphic/ColorCount.swift
+++ b/Sources/PaletteKit/Graphic/ColorCount.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Number of distinct palette colors used along a gradient graphic.
+///
+/// Shared by ``PaletteGraphic`` and ``AnimatedPaletteGraphic``. Colors are taken
+/// from the palette in population order (most prominent first).
+public enum ColorCount: Int, CaseIterable, Identifiable, Sendable {
+    case two = 2
+    case three = 3
+    case four = 4
+    case five = 5
+
+    public var id: Int { rawValue }
+}

--- a/Sources/PaletteKit/Graphic/PaletteGraphic.swift
+++ b/Sources/PaletteKit/Graphic/PaletteGraphic.swift
@@ -124,16 +124,6 @@ extension PaletteGraphic {
     }
 }
 
-/// Number of distinct colors used along a ``PaletteGraphic`` gradient.
-public enum ColorCount: Int, CaseIterable, Identifiable, Sendable {
-    case two   = 2
-    case three = 3
-    case four  = 4
-    case five  = 5
-
-    public var id: Int { rawValue }
-}
-
 /// How a ``PaletteGraphic`` flows its color stops across the bounds.
 public enum GradientDirection: String, CaseIterable, Identifiable, Sendable {
     /// Diagonal flow from `linearStart` to `linearEnd`. Default anchors

--- a/Tests/PaletteKitTests/AnimatedPaletteGraphicConfigurationTests.swift
+++ b/Tests/PaletteKitTests/AnimatedPaletteGraphicConfigurationTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import PaletteKit
+
+@Suite("AnimatedPaletteGraphic.Configuration")
+struct AnimatedPaletteGraphicConfigurationTests {
+    @Test("defaults: three colors, regular speed, animated")
+    func defaults() {
+        let c = AnimatedPaletteGraphic.Configuration()
+        #expect(c.colorCount == .three)
+        #expect(c.speed == .regular)
+        #expect(c.isAnimated)
+    }
+
+    @Test("FlowSpeed presets")
+    func speeds() {
+        #expect(FlowSpeed.slow.multiplier == 0.1)
+        #expect(FlowSpeed.regular.multiplier == 0.2)
+        #expect(FlowSpeed.fast.multiplier == 0.3)
+        #expect(FlowSpeed(-5).multiplier == 0)   // clamps
+    }
+
+    @Test("power is fixed at 4")
+    func power() {
+        #expect(AnimatedPaletteGraphic.Configuration.power == 4)
+    }
+
+    @Test("resolves LAB colors padded to colorCount, population order")
+    func resolveColors() {
+        let palette = Palette(colors: [
+            PaletteColor(r: 18, g: 58, b: 143),
+            PaletteColor(r: 242, g: 194, b: 0),
+        ], colorSpaceUsed: .sRGB)
+
+        let three = AnimatedPaletteGraphic.Configuration(colorCount: .three).resolveLABColors(from: palette)
+        #expect(three.count == 3)
+        // First resolved color is the palette's first (dominant), in LAB.
+        #expect(three[0] == LABConversion.rgbToLAB(palette.colors[0].rgb))
+
+        let five = AnimatedPaletteGraphic.Configuration(colorCount: .five).resolveLABColors(from: palette)
+        #expect(five.count == 5)
+    }
+}

--- a/Tests/PaletteKitTests/FlowMotionTests.swift
+++ b/Tests/PaletteKitTests/FlowMotionTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import simd
+import Testing
+@testable import PaletteKit
+
+@Suite("FlowMotion")
+struct FlowMotionTests {
+    @Test("positions stay near the unit square")
+    func bounds() {
+        let motion = FlowMotion(count: 6, seed: 42)
+        for _ in 0..<600 { motion.advance(dt: 1.0 / 60.0, speed: 1) }
+        for p in motion.positions {
+            #expect(p.x >= -0.3 && p.x <= 1.3)   // springs may overshoot slightly
+            #expect(p.y >= -0.3 && p.y <= 1.3)
+        }
+    }
+
+    @Test("is deterministic for a fixed seed")
+    func deterministic() {
+        let a = FlowMotion(count: 4, seed: 7)
+        let b = FlowMotion(count: 4, seed: 7)
+        for _ in 0..<120 { a.advance(dt: 1.0 / 60.0, speed: 1); b.advance(dt: 1.0 / 60.0, speed: 1) }
+        for (pa, pb) in zip(a.positions, b.positions) {
+            #expect(pa.x == pb.x)
+            #expect(pa.y == pb.y)
+        }
+    }
+
+    @Test("different seeds give different initial layouts")
+    func seedVaries() {
+        let a = FlowMotion(count: 4, seed: 1)
+        let b = FlowMotion(count: 4, seed: 2)
+        #expect(a.positions != b.positions)
+    }
+
+    @Test("dt of zero does not move points")
+    func frozen() {
+        let motion = FlowMotion(count: 3, seed: 1)
+        let before = motion.positions
+        motion.advance(dt: 0, speed: 1)
+        #expect(motion.positions == before)
+    }
+}

--- a/Tests/PaletteKitTests/LABConversionTests.swift
+++ b/Tests/PaletteKitTests/LABConversionTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import PaletteKit
+
+@Suite("LABConversion")
+struct LABConversionTests {
+    @Test("white maps to L≈100, a≈0, b≈0")
+    func white() {
+        let lab = LABConversion.rgbToLAB(RGB(r: 255, g: 255, b: 255))
+        #expect(abs(lab.x - 100) < 0.5)
+        #expect(abs(lab.y) < 0.5)
+        #expect(abs(lab.z) < 0.5)
+    }
+
+    @Test("black maps to L≈0")
+    func black() {
+        let lab = LABConversion.rgbToLAB(RGB(r: 0, g: 0, b: 0))
+        #expect(abs(lab.x) < 0.5)
+    }
+
+    @Test("round-trips RGB -> LAB -> RGB within tolerance")
+    func roundTrip() {
+        for rgb in [RGB(r: 18, g: 58, b: 143), RGB(r: 242, g: 194, b: 0), RGB(r: 120, g: 90, b: 200)] {
+            let back = LABConversion.labToRGB(LABConversion.rgbToLAB(rgb))
+            #expect(abs(Int(back.r) - Int(rgb.r)) <= 2)
+            #expect(abs(Int(back.g) - Int(rgb.g)) <= 2)
+            #expect(abs(Int(back.b) - Int(rgb.b)) <= 2)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AnimatedPaletteGraphic` (SwiftUI) and `AnimatedPaletteGraphicView` (UIKit): a "living gradient" that renders an extracted `Palette` as a multi-point, LAB-blended, spring-animated flow.
- Configuration: `colorCount` (`.two`…`.five`), `speed` (`FlowSpeed`: `.slow`/`.regular`/`.fast`), `isAnimated`. Honors Reduce Motion and Low Power Mode (holds a static frame) and pauses while off-screen.
- Single inline-source Metal engine (no `.metallib` resource bundle); SwiftUI wraps the UIKit `MTKView` via `UIViewRepresentable`.
- Extract `ColorCount` into its own file so it is shared cross-platform by `PaletteGraphic` and `AnimatedPaletteGraphic`.
- Demo: "Animate Graphic" lab in PaletteKitDemo (color count / speed / animated toggle).

## Test Plan
- [ ] `swift test` — 46 tests pass (LAB conversion, FlowMotion, Configuration + existing suites)
- [ ] iOS simulator build: `xcodebuild -scheme PaletteKit -sdk iphonesimulator build`
- [ ] PaletteKitDemo → pick a photo → **Animate Graphic** → verify flow, color-count/speed controls, and that Reduce Motion freezes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)