### PR TITLE
fix: bump paletteKitVersion to 2.1.0

### DIFF
--- a/Sources/PaletteKit/PaletteKit.swift
+++ b/Sources/PaletteKit/PaletteKit.swift
@@ -1,4 +1,4 @@
 import Foundation
 
 /// The currently-shipped PaletteKit version string. Follows semver.
-public let paletteKitVersion = "1.7.0"
+public let paletteKitVersion = "2.1.0"


### PR DESCRIPTION
The `paletteKitVersion` constant was left at `1.7.0` through the v2.0/v2.1 releases. Bump it to `2.1.0` to match the current shipped version.