### PR TITLE
Improve PaletteKit DocC discovery and API guidance

### DIFF
--- a/PaletteKit.docc/AlgorithmDeepDive.md
+++ b/PaletteKit.docc/AlgorithmDeepDive.md
@@ -5,9 +5,9 @@ How PaletteKit turns pixels into a palette.
 ## Modified Median Cut Quantization
 
 The core algorithm is Modified Median Cut Quantization (MMCQ), the same
-algorithm used by color-thief. PaletteKit ports the
-`@lokesh.dhakar/quantize` reference verbatim so cross-verification stays
-simple.
+algorithm family used by color-thief. PaletteKit follows the reference's
+histogram and median-cut structure in an independent Swift implementation.
+Exact palette parity is not guaranteed.
 
 ### Step 1: reduced histogram
 
@@ -25,11 +25,11 @@ color within it.
 
 ### Step 3: median cut
 
-VBoxes are held in a priority queue. On each iteration we pop the "best"
-box, cut it along its widest RGB axis at the bin that passes the halfway
-mark in population, and push the two children back. The split chooses
-the bin immediately past the midpoint and nudges the cut into the larger
-half to keep both children non-empty.
+VBoxes are held in a priority queue. On each iteration we pop the "best" box,
+cut it along the widest axis in the current three-channel quantization space,
+and push the two children back. The split chooses the bin immediately past the
+population midpoint and nudges the cut into the larger half to keep both
+children non-empty.
 
 ### Step 4: two-phase iteration
 
@@ -48,14 +48,19 @@ proportions, and wraps each entry in ``PaletteColor``.
 
 `colorSpace: .oklch` is the default. Pixels are converted to OKLCH,
 scaled to the 0-255 integer range MMCQ expects, quantized, then mapped
-back to sRGB (or Display P3 when the source image is P3). The result is
-a more perceptually uniform palette — colors "feel" evenly spaced to the
-eye rather than being evenly spaced in RGB.
+back to clamped, 8-bit sRGB. The result is a more perceptually uniform palette
+— colors "feel" evenly spaced to the eye rather than being evenly spaced in
+RGB.
 
 - ``OKLCHConversion/rgbToOKLCH(_:)`` implements the Oklab M1 matrix
   + cube-root + Lab-to-LCh reduction.
 - ``OKLCHConversion/displayP3ToOKLCH(_:)`` uses the P3-to-linear-sRGB
-  matrix so wide-gamut chroma survives the round-trip.
+  matrix so Display P3 source coordinates are interpreted correctly before
+  quantization.
+
+The built-in SwiftUI, UIKit, and Core Graphics result adapters emit sRGB. See
+<doc:ColorSpaces> for the distinction between P3-aware source processing and
+end-to-end P3 rendering.
 
 ## Semantic swatches
 

--- a/PaletteKit.docc/AsyncLoading.md
+++ b/PaletteKit.docc/AsyncLoading.md
@@ -118,4 +118,3 @@ For UIKit, set ``AsyncPaletteGraphicView/onFailure`` directly.
 
 ### Transitions
 - ``AsyncPaletteGraphicTransition``
-- ``SwiftUI/View/asyncPaletteGraphicTransition(_:)``

--- a/PaletteKit.docc/ChoosingAnExtractionResult.md
+++ b/PaletteKit.docc/ChoosingAnExtractionResult.md
@@ -1,0 +1,87 @@
+# Choosing an Extraction Result
+
+PaletteKit can return one dominant color, a ranked palette, or a set of
+semantic swatches. Choose the smallest result that represents the UI decision
+you need to make.
+
+## Compare the results
+
+| Result | Use it for | API |
+| --- | --- | --- |
+| Dominant color | One representative accent, placeholder, or background color | ``PaletteExtractor/dominantColor(from:options:)`` |
+| Ranked palette | Several representative colors with population data | ``PaletteExtractor/palette(from:options:)`` |
+| Semantic swatches | Optional vibrant, muted, dark, and light UI roles | ``PaletteExtractor/swatches(from:options:)`` |
+
+All three APIs use the same image sources and ``ExtractionOptions``. They are
+`async throws` and return `Sendable` values.
+
+## Extracting one dominant color
+
+Use a dominant color when the interface needs one representative value:
+
+```swift
+let dominant = try await PaletteExtractor().dominantColor(
+    from: .data(imageData)
+)
+```
+
+The result is optional because a palette can be empty, including when a custom
+quantizer returns no colors. The method runs palette extraction with the
+supplied options and returns the most populous ``PaletteColor``.
+
+## Building a ranked palette
+
+Use a ``Palette`` when the interface needs several colors or population data:
+
+```swift
+let palette = try await PaletteExtractor().palette(
+    from: .data(imageData),
+    options: ExtractionOptions(colorCount: 8)
+)
+
+for color in palette {
+    print(color.hex, color.population, color.proportion)
+}
+```
+
+Palette colors are sorted by population. ``Palette/dominant`` returns the
+first color without running another extraction.
+
+## Creating semantic swatches
+
+Use ``SwatchMap`` when the interface needs role-based color choices:
+
+```swift
+let swatches = try await PaletteExtractor().swatches(from: .data(imageData))
+
+let background = swatches.color(
+    for: .vibrant,
+    fallback: .black
+)
+```
+
+The swatch classifier looks for up to six roles: vibrant, muted, dark vibrant,
+dark muted, light vibrant, and light muted. Each role is optional because an
+image may not contain a suitable unused color in that role's lightness and
+chroma range. The swatch method raises a smaller requested color count to 16
+so the classifier has enough candidates.
+
+## Reusing one extraction
+
+`swatches(from:options:)` performs its own palette extraction. If an interface
+needs both a ``Palette`` and a ``SwatchMap``, extract at least 16 candidates and
+classify that palette directly:
+
+```swift
+let palette = try await PaletteExtractor().palette(
+    from: .data(imageData),
+    options: ExtractionOptions(colorCount: 16)
+)
+let swatches = SwatchClassifier().classify(palette: palette)
+```
+
+This avoids decoding and quantizing the same image twice. PaletteKit's async
+graphic views can cache URL-based rendering workflows; see <doc:AsyncLoading>.
+
+For source-specific examples, see <doc:ImageColorExtraction>. For color-space
+behavior, see <doc:ColorSpaces>.

--- a/PaletteKit.docc/ColorSpaces.md
+++ b/PaletteKit.docc/ColorSpaces.md
@@ -1,0 +1,103 @@
+# Display P3 and OKLCH Color Extraction
+
+Understand how PaletteKit detects Display P3 images, uses OKLCH for
+perceptual quantization, and returns colors to SwiftUI and UIKit.
+
+## Does PaletteKit support Display P3 images?
+
+PaletteKit supports Display P3-aware input analysis. It does not preserve a P3
+output profile through the default pipeline. PaletteKit detects sRGB and
+Display P3 `CGImage` color spaces while it decodes an image. With the default
+`colorSpace: .oklch` option, it applies the matching sRGB-to-OKLCH or Display
+P3-to-OKLCH conversion before quantization. This avoids treating Display P3
+channel values as if they were sRGB during perceptual clustering.
+
+The resulting ``Palette/colorSpaceUsed`` value records the detected source
+space when the default OKLCH pipeline is used.
+
+> Important: The default OKLCH path converts representative colors back to
+> sRGB and clamps channels to the sRGB range. ``PaletteColor`` stores that
+> untagged 8-bit RGB triple, and its SwiftUI `ShapeStyle`, `UIColor`, and
+> ``PaletteColor/cgColor`` adapters emit sRGB-tagged colors. A
+> `colorSpaceUsed` value of `.displayP3` records the detected input in this
+> mode; it does not make the returned RGB values Display P3 coordinates.
+
+## Why does PaletteKit use OKLCH?
+
+RGB channel distance is not perceptually uniform: two equally sized numeric
+changes can look very different to a person. OKLCH separates lightness,
+chroma, and hue, so PaletteKit can run MMCQ over a space that better reflects
+visible differences between colors.
+
+The default pipeline is:
+
+1. Decode and rasterize the image in its detected sRGB or Display P3 space.
+2. Filter and sample pixels according to ``ExtractionOptions``.
+3. Convert sampled pixels to scaled OKLCH coordinates.
+4. Quantize those coordinates with the selected MMCQ backend.
+5. Convert representative colors to clamped, 8-bit sRGB ``PaletteColor``
+   values.
+
+See <doc:AlgorithmDeepDive> for the histogram and median-cut details.
+
+## Which color-space option should I choose?
+
+| Option | Behavior | Use it when |
+| --- | --- | --- |
+| ``ColorSpace/oklch`` | Uses source-aware OKLCH conversion before MMCQ | You want the recommended perceptual palette extraction path |
+| ``ColorSpace/sRGB`` | Quantizes rasterized channel values directly in RGB space | You need direct RGB-space MMCQ behavior |
+| ``ColorSpace/displayP3`` | Quantizes rasterized channel values directly and sets `colorSpaceUsed` to Display P3 | You know the source is P3 and will interpret raw channels yourself |
+
+For most applications, keep the default `.oklch` setting.
+
+> Note: Selecting `.sRGB` or `.displayP3` does not convert channel values from
+> one RGB color space into the other. Only use a direct RGB mode when the
+> source space is known and matches the interpretation your application will
+> apply to the raw channels.
+
+```swift
+let palette = try await PaletteExtractor().palette(
+    from: .data(imageData),
+    options: ExtractionOptions(colorSpace: .oklch)
+)
+```
+
+## How do I check whether the source was Display P3?
+
+With the default `.oklch` mode, inspect ``Palette/colorSpaceUsed`` to see the
+detected source space:
+
+```swift
+switch palette.colorSpaceUsed {
+case .displayP3:
+    print("Display P3 source")
+case .sRGB:
+    print("sRGB source")
+case .oklch:
+    print("Custom OKLCH metadata")
+}
+```
+
+In direct `.sRGB` or `.displayP3` mode, `colorSpaceUsed` records the selected
+mode instead. It is extraction metadata, not a color profile embedded in each
+``PaletteColor``.
+
+The computed ``PaletteColor/oklch`` property also interprets the stored RGB
+channels as sRGB.
+
+## Do SwiftUI and UIKit preserve Display P3 output?
+
+Not through the built-in convenience adapters. `PaletteColor.resolve(in:)`,
+`UIColor(_:)`, and ``PaletteColor/cgColor`` all interpret the returned RGB
+channels as sRGB. This makes their behavior deterministic across UI layers.
+
+The default `.oklch` result cannot be reinterpreted as Display P3 by combining
+`colorSpaceUsed` with the raw channels; those channels have already been
+converted to sRGB. If your application requires P3 output, PaletteKit does not
+currently provide an end-to-end color-managed convenience path.
+
+An advanced caller that knows the input is genuinely Display P3 can select
+`.displayP3`, quantize those rasterized channels directly, and construct a P3
+platform color without using the built-in adapters. This mode does not verify
+or convert the source space, so validate the full path with representative
+wide-gamut assets.

--- a/PaletteKit.docc/FAQ.md
+++ b/PaletteKit.docc/FAQ.md
@@ -1,0 +1,117 @@
+# PaletteKit FAQ
+
+Direct answers to common questions about dominant color extraction, SwiftUI,
+UIKit, Display P3, OKLCH, MMCQ, Metal, and PaletteKit's relationship to
+color-thief.
+
+## What is PaletteKit?
+
+PaletteKit is a Swift 6 package for extracting dominant colors, ordered color
+palettes, and six semantic swatch roles from images on Apple platforms. Its
+extraction methods are async, while the extractor and result values are
+`Sendable`. Result types integrate with SwiftUI, UIKit, and Core Graphics.
+
+## Which platforms does PaletteKit support?
+
+The package declares iOS 17 and macOS 14 as its minimum platforms. SwiftUI
+integration is available where SwiftUI can be imported; the `UIColor`
+initializer and UIKit views are available on UIKit platforms.
+
+## How do I extract the dominant color from an image in Swift?
+
+Pass an ``ImageSource/cgImage(_:)``, ``ImageSource/data(_:)``, or local
+``ImageSource/url(_:)`` value to
+``PaletteExtractor/dominantColor(from:options:)``:
+
+```swift
+let color = try await PaletteExtractor().dominantColor(
+    from: .cgImage(cgImage)
+)
+```
+
+For `UIImage`, remote URL, palette, and semantic-swatch examples, see
+<doc:ImageColorExtraction>.
+
+## Does PaletteKit download remote images?
+
+No. ``ImageSource/url(_:)`` is for an image file that ImageIO can read. Fetch a
+remote HTTP image with `URLSession` or your networking layer, then pass the
+encoded bytes as ``ImageSource/data(_:)``.
+
+## Does PaletteKit accept UIImage or SwiftUI Image directly?
+
+`UIImage` and SwiftUI `Image` are not ``ImageSource`` cases. For a `UIImage`
+with a `CGImage` backing store, pass `image.cgImage` as `.cgImage`. For a
+SwiftUI `Image`, retain the original `CGImage`, `Data`, or file URL used to
+create the view and extract from that source.
+
+## Does PaletteKit work with SwiftUI and UIKit?
+
+Yes. ``PaletteColor`` conforms to SwiftUI `ShapeStyle`, so it can be used with
+`fill`, `foregroundStyle`, and other styling APIs. UIKit code can construct a
+`UIColor` with `UIColor(paletteColor)`, and ``PaletteColor/cgColor`` works with
+Core Graphics and `CALayer`.
+
+PaletteKit also includes palette-driven SwiftUI and UIKit graphic views. Start
+with <doc:GettingStarted>, <doc:Card>, or <doc:AsyncLoading>.
+
+## Does PaletteKit support Display P3 and OKLCH?
+
+PaletteKit detects Display P3 inputs and uses a P3-aware conversion when the
+default OKLCH quantization path is selected. Built-in SwiftUI and UIKit output
+adapters are sRGB-tagged, so P3-aware extraction should not be confused with
+end-to-end P3 rendering. See <doc:ColorSpaces> for the exact pipeline.
+
+## What is the difference between a palette and semantic swatches?
+
+A ``Palette`` is an ordered collection of representative colors, sorted by
+population. A ``SwatchMap`` classifies palette candidates into six optional UI
+roles: vibrant, muted, dark vibrant, dark muted, light vibrant, and light
+muted. Use a palette for raw color choices and swatches when your UI needs
+role-based accents or backgrounds.
+
+## Does PaletteKit provide readable text colors?
+
+Each ``PaletteColor`` exposes black-versus-white contrast ratios and a
+``PaletteColor/textColor`` recommendation. Each ``Swatch`` also includes
+`titleTextColor` and `bodyTextColor`. These are useful starting points, but
+your application should still validate the final foreground/background pair
+against its own WCAG target, font size, and presentation context.
+
+## How is PaletteKit related to color-thief?
+
+PaletteKit is a ground-up Swift implementation inspired by color-thief and its
+MMCQ algorithm family. It is not a drop-in port of the JavaScript API. It adds
+Apple-native ImageIO decoding, Swift concurrency, OKLCH-based quantization,
+semantic swatches, optional Metal histogram computation, and native UI result
+types. Exact palette parity is not guaranteed.
+
+## Does PaletteKit use the GPU automatically?
+
+No. ``QuantizerSelection/auto`` currently selects the CPU MMCQ backend. Choose
+`.metal` explicitly when testing a large, non-downsampled workload. Metal has
+startup costs, and device, shader, or pipeline creation failures on a
+Metal-capable target are reported as extraction errors. See
+<doc:PerformanceTuning> and measure with representative images.
+
+## How does PaletteKit handle large photos?
+
+The default downsampling policy targets up to about one million raster pixels
+for `Data` and URL inputs, then the default quality setting samples every tenth
+pixel. Thumbnail decoding can fall back to a full decode, and a `CGImage` is
+already decoded when passed to PaletteKit. You can tune both settings through
+``ExtractionOptions``. See <doc:Options> before disabling downsampling.
+
+## Is PaletteExtractor thread-safe?
+
+``PaletteExtractor`` is a stateless `Sendable` value type. You can construct
+one per call site or share it across actors. Its public methods are
+`async throws` and check for cooperative task cancellation between extraction
+stages.
+
+## Why can a semantic swatch be nil?
+
+Each semantic role has lightness and chroma constraints. A role is `nil` when
+the extracted palette has no unused candidate within that role's range. Keep a
+fallback ``PaletteColor`` in UI code or use the convenience lookup methods on
+``SwatchMap``.

--- a/PaletteKit.docc/ImageColorExtraction.md
+++ b/PaletteKit.docc/ImageColorExtraction.md
@@ -1,0 +1,146 @@
+# Extracting Image Colors in Swift
+
+Use PaletteKit to extract a dominant color, an ordered color palette, or
+semantic swatches from `CGImage`, image `Data`, and local image URLs in Swift.
+
+## Overview
+
+``PaletteExtractor`` is PaletteKit's async, `Sendable` entry point for image
+color extraction on iOS and macOS. Choose the result that matches the UI you
+are building:
+
+| Goal | API | Result |
+| --- | --- | --- |
+| Find one representative image color | ``PaletteExtractor/dominantColor(from:options:)`` | ``PaletteColor``? |
+| Extract several colors ordered by population | ``PaletteExtractor/palette(from:options:)`` | ``Palette`` |
+| Find vibrant, muted, dark, and light roles | ``PaletteExtractor/swatches(from:options:)`` | ``SwatchMap`` |
+
+All three methods are `async throws`, honor task cancellation, and accept the
+same ``ExtractionOptions``.
+
+For help choosing between these result types, see
+<doc:ChoosingAnExtractionResult>.
+
+## Extracting the dominant color from a UIImage
+
+Convert a `UIImage` that has a `CGImage` backing store to
+``ImageSource/cgImage(_:)``:
+
+```swift
+import PaletteKit
+import UIKit
+
+func dominantColor(in image: UIImage) async throws -> PaletteColor? {
+    guard let cgImage = image.cgImage else { return nil }
+    return try await PaletteExtractor().dominantColor(from: .cgImage(cgImage))
+}
+```
+
+Some `UIImage` values, including images backed only by `CIImage`, do not expose
+`cgImage`. In that case, render a `CGImage` first or pass the original encoded
+bytes through ``ImageSource/data(_:)``.
+
+## Extracting a palette from a CGImage
+
+Call `palette(from:options:)` and choose the maximum number of representative
+colors with ``ExtractionOptions/colorCount``:
+
+```swift
+import CoreGraphics
+import PaletteKit
+
+func imagePalette(from image: CGImage) async throws -> Palette {
+    try await PaletteExtractor().palette(
+        from: .cgImage(image),
+        options: ExtractionOptions(colorCount: 8)
+    )
+}
+```
+
+The returned ``Palette`` is a collection sorted by population. Its
+``Palette/dominant`` property is the first, most populous color, and each
+``PaletteColor`` includes `hex`, `hsl`, `oklch`, `population`, and
+`proportion` values.
+
+## Loading a local or remote image
+
+Use ``ImageSource/url(_:)`` for an image file that is already on disk:
+
+```swift
+let palette = try await PaletteExtractor().palette(from: .url(fileURL))
+```
+
+For a remote HTTP URL, download the bytes with your networking layer and pass
+them as `Data`. This keeps networking policy, authentication, caching, and
+retry behavior outside the extraction library:
+
+```swift
+let (data, _) = try await URLSession.shared.data(from: remoteURL)
+let palette = try await PaletteExtractor().palette(from: .data(data))
+```
+
+## Rendering extracted colors in SwiftUI
+
+``PaletteColor`` conforms to `ShapeStyle`, so it works directly with common
+SwiftUI styling modifiers:
+
+```swift
+import PaletteKit
+import SwiftUI
+
+struct PaletteStrip: View {
+    let palette: Palette
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(palette.prefix(5)), id: \.self) { color in
+                Rectangle().fill(color)
+            }
+        }
+    }
+}
+```
+
+The built-in `ShapeStyle` conformance resolves the color as sRGB. See
+<doc:ColorSpaces> for the distinction between Display P3-aware extraction and
+UI rendering.
+
+## Rendering extracted colors in UIKit
+
+Create a `UIColor` with PaletteKit's convenience initializer, or use
+``PaletteColor/cgColor`` for Core Graphics and `CALayer`:
+
+```swift
+let swatches = try await PaletteExtractor().swatches(from: .data(imageData))
+
+if let vibrant = swatches.vibrant {
+    view.backgroundColor = UIColor(vibrant.color)
+    label.textColor = UIColor(vibrant.titleTextColor)
+}
+```
+
+The UIKit and Core Graphics adapters produce sRGB-tagged colors.
+
+## Tuning extraction for large photos
+
+The default ``Downsample/automatic(maxPixels:)`` setting targets up to about
+one million raster pixels, and the default ``Quality/default`` samples every
+tenth pixel. For `Data` and URL inputs, PaletteKit asks ImageIO for a thumbnail
+first; ImageIO can fall back to a full decode. A `CGImage` is already decoded
+before extraction begins. Adjust either value when your workload favors more
+detail or less work:
+
+```swift
+let options = ExtractionOptions(
+    quality: .stride(5),
+    downsample: .automatic(maxPixels: 500_000)
+)
+
+let palette = try await PaletteExtractor().palette(
+    from: .data(imageData),
+    options: options
+)
+```
+
+For backend selection and measurement guidance, see <doc:Options> and
+<doc:PerformanceTuning>.

--- a/PaletteKit.docc/PaletteKit.md
+++ b/PaletteKit.docc/PaletteKit.md
@@ -1,27 +1,30 @@
 # ``PaletteKit``
 
-High-performance iOS-native color palette extraction with MMCQ, OKLCH
-perceptual quantization, Display P3 wide-gamut support, semantic swatches,
-and an optional Metal backend.
+Swift image color extraction for dominant colors, ordered palettes, and
+semantic swatches, with MMCQ, OKLCH, Display P3-aware input handling, and an
+optional Metal backend.
 
 ## Overview
 
-PaletteKit extracts dominant colors, palettes, and semantic swatches from
-images on iOS. It is a ground-up Swift implementation inspired by
-[color-thief v3](https://github.com/lokesh/color-thief) that takes advantage
-of Apple-native tooling the web port cannot reach: `CGImageSource` thumbnail
-decoding, EXIF-aware orientation, Display P3 wide-gamut preservation, OKLCH
-perceptual quantization, and a Metal compute-shader histogram path.
+PaletteKit is a Swift 6 image color extraction library for iOS and macOS. It
+returns dominant colors, ranked palettes, and semantic swatches, with native
+result adapters for SwiftUI, UIKit, and Core Graphics. PaletteKit is an
+independent Swift implementation inspired by
+[color-thief v3](https://github.com/lokesh/color-thief). It uses Apple-native
+facilities, including `CGImageSource` thumbnail decoding, EXIF-aware
+orientation, Display P3-aware conversion, OKLCH perceptual quantization, and a
+Metal compute-shader histogram path.
 
-- **Async-only, Sendable API.** Every entry point is `async throws`.
+- **Async-only, Sendable API.** Every extraction entry point is `async throws`.
   `PaletteExtractor` is a value type so you can use one per call site or
   share it freely across actors.
 - **Rich `PaletteColor`.** Returns more than just RGB — hex, HSL, OKLCH,
   WCAG contrast, text color recommendations, population, proportion.
 - **Strategy-pattern quantizers.** MMCQ on CPU by default, Metal for
   large images, or bring your own `Quantizer`.
-- **Wide-gamut aware.** Display P3 images keep their chroma through the
-  OKLCH conversion instead of being clipped to sRGB.
+- **Display P3-aware extraction.** The default path detects P3 sources and
+  uses a P3-to-OKLCH conversion before quantization. Built-in UI adapters emit
+  sRGB; see <doc:ColorSpaces> for the exact boundary.
 
 ## Getting Started
 
@@ -32,7 +35,7 @@ let extractor = PaletteExtractor()
 let color = try await extractor.dominantColor(from: .cgImage(image))
 print(color?.hex ?? "no dominant color")
 
-let palette = try await extractor.palette(from: .url(url))
+let palette = try await extractor.palette(from: .url(fileURL))
 palette.forEach { print($0.hex, $0.proportion) }
 
 let swatches = try await extractor.swatches(from: .data(data))
@@ -44,17 +47,30 @@ swatches.vibrant?.color.hex
 Thanks to [color-thief](https://github.com/lokesh/color-thief) by
 Lokesh Dhakar (MIT) for charting the way — the MMCQ algorithm family,
 OKLCH-first quantization, and the six-role swatch layout shaped
-PaletteKit's direction. PaletteKit reimagines those ideas for iOS with a
-Metal compute histogram, Display P3 preservation, Swift 6 concurrency, and
-CGImageSource-based decoding, while keeping the algorithmic core
-compatible so outputs can be cross-verified against the reference.
+PaletteKit's direction. PaletteKit reimagines those ideas for Apple platforms
+with a Metal compute histogram, Display P3-aware input conversion, Swift 6
+concurrency, and CGImageSource-based decoding. PaletteKit is an independent
+Swift implementation rather than an API-compatible wrapper, so exact palette
+parity is not guaranteed.
 
 ## Topics
+
+### Start here
+- <doc:GettingStarted>
+- <doc:ChoosingAnExtractionResult>
+- <doc:ImageColorExtraction>
 
 ### Extracting colors
 - ``PaletteExtractor``
 - ``ExtractionOptions``
 - ``ImageSource``
+
+### Working with color
+- <doc:ColorSpaces>
+- ``RGB``
+- ``HSL``
+- ``OKLCH``
+- ``OKLCHConversion``
 
 ### Result types
 - ``PaletteColor``
@@ -62,6 +78,14 @@ compatible so outputs can be cross-verified against the reference.
 - ``Swatch``
 - ``SwatchMap``
 - ``SwatchRole``
+- ``SwatchClassifier``
+
+### Rendering palettes
+- <doc:Card>
+- ``PaletteGraphic``
+- ``PaletteGraphicView``
+- ``PaletteMeshGraphic``
+- ``AnimatedPaletteGraphic``
 
 ### Async loading
 - <doc:AsyncLoading>
@@ -70,11 +94,13 @@ compatible so outputs can be cross-verified against the reference.
 - ``PaletteCache``
 - ``AsyncPaletteGraphicTransition``
 
-### Color math
-- ``RGB``
-- ``HSL``
-- ``OKLCH``
-- ``OKLCHConversion``
+### Tuning performance
+- <doc:Options>
+- <doc:PerformanceTuning>
+
+### Understanding PaletteKit
+- <doc:FAQ>
+- <doc:AlgorithmDeepDive>
 
 ### Custom backends
 - ``Quantizer``

--- a/PaletteKit.docc/Tutorials/GettingStarted.md
+++ b/PaletteKit.docc/Tutorials/GettingStarted.md
@@ -22,9 +22,11 @@ func extractDominant(cgImage: CGImage) async throws -> PaletteColor? {
 }
 ```
 
-`dominantColor(from:)` runs a 5-color extraction and returns the most
-populous one. The `PaletteColor` value carries `hex`, `hsl`, `oklch`,
-`contrast`, and `textColor` without any extra calls.
+`dominantColor(from:)` runs palette extraction with the supplied options and
+returns the most populous color. The default `colorCount` is 10; values below
+the valid palette range are normalized to 5 for this convenience method. The
+`PaletteColor` value carries `hex`, `hsl`, `oklch`, `contrast`, and `textColor`
+without any extra calls.
 
 ### Extract a palette
 
@@ -40,7 +42,9 @@ for entry in palette {
 ```
 
 `palette` is a `Collection<PaletteColor>` sorted by population. Its
-`colorSpaceUsed` tells you whether the result lives in sRGB or Display P3.
+`colorSpaceUsed` records the color space detected or selected by the extraction
+pipeline; individual `PaletteColor` values do not embed a color profile. See
+<doc:ColorSpaces> for details.
 
 ### Get semantic swatches
 
@@ -52,8 +56,9 @@ if let vibrant = swatches.vibrant {
 }
 ```
 
-Each `Swatch` also exposes `titleTextColor` and `bodyTextColor` so you can
-render accessible text directly on top of the swatch.
+Each `Swatch` also exposes `titleTextColor` and `bodyTextColor` as recommended
+black or white foreground colors. Validate the final combination against your
+application's accessibility target.
 
 ## Using the result
 
@@ -64,8 +69,11 @@ render accessible text directly on top of the swatch.
 `PaletteColor` conforms to `ShapeStyle` (iOS 17+), so it slots directly into `.fill`, `.foregroundStyle`, `.background`, `.tint`, and `.border`:
 
 ```swift
-let palette = try await extractor.palette(from: .data(imageData))
-let swatches = try await extractor.swatches(from: .data(imageData))
+let palette = try await extractor.palette(
+    from: .data(imageData),
+    options: ExtractionOptions(colorCount: 16)
+)
+let swatches = SwatchClassifier().classify(palette: palette)
 
 VStack {
     Rectangle()
@@ -88,8 +96,11 @@ Internally `resolve(in:)` produces a `Color.Resolved` tagged sRGB.
 For UIKit, use the `UIColor(_:)` convenience initializer:
 
 ```swift
-let palette = try await extractor.palette(from: .data(imageData))
-let swatches = try await extractor.swatches(from: .data(imageData))
+let palette = try await extractor.palette(
+    from: .data(imageData),
+    options: ExtractionOptions(colorCount: 16)
+)
+let swatches = SwatchClassifier().classify(palette: palette)
 
 if let vibrant = swatches.vibrant {
     view.backgroundColor = UIColor(vibrant.color)
@@ -124,6 +135,10 @@ to work; pick whichever reads better at the callsite.
 
 ## Next steps
 
+- See <doc:ImageColorExtraction> for `UIImage`, `CGImage`, local file, and
+  remote image examples.
+- See <doc:ColorSpaces> for Display P3 input handling, OKLCH quantization, and
+  the sRGB output boundary.
 - See <doc:Options> for fine-grained control over quality, color count,
   filters, and backend selection.
 - See <doc:PerformanceTuning> for the Metal path and measurement tips.

--- a/PaletteKit.docc/Tutorials/Options.md
+++ b/PaletteKit.docc/Tutorials/Options.md
@@ -5,8 +5,9 @@ Tune extraction via ``ExtractionOptions``.
 ## Overview
 
 Every public method on ``PaletteExtractor`` accepts an ``ExtractionOptions``.
-The defaults mirror color-thief's (colorCount=10, quality=10, OKLCH,
-ignoreWhite=true) so results are predictable if you are porting over.
+The defaults follow color-thief v3's familiar color-count, quality, OKLCH, and
+white-filter values. PaletteKit is an independent implementation, so exact
+palette parity is not guaranteed.
 
 ### Quality and size
 
@@ -21,8 +22,10 @@ ExtractionOptions(
 - `quality` is a stride multiplier. `.stride(1)` samples every pixel;
   `.stride(10)` (the default) is typically fast enough and still
   representative.
-- `downsample` routes through `CGImageSourceCreateThumbnailAtIndex` so a
-  large photo never allocates a full RGBA buffer.
+- For `Data` and URL sources, `downsample` first asks ImageIO for a thumbnail
+  through `CGImageSourceCreateThumbnailAtIndex`. ImageIO can fall back to a
+  full decode if thumbnail creation fails. A `CGImage` source is already
+  decoded before PaletteKit receives it and is resized when needed.
 
 ### Filtering
 
@@ -44,25 +47,27 @@ ExtractionOptions(
 
 ```swift
 ExtractionOptions(colorSpace: .oklch)   // default
-ExtractionOptions(colorSpace: .sRGB)    // color-thief v2 parity
+ExtractionOptions(colorSpace: .sRGB)    // direct RGB-space MMCQ
 ```
 
-Display P3 input is auto-detected. When `colorSpace == .oklch` the
-resulting palette stays in the source color space — the OKLCH conversion
-is used only inside the quantization step for perceptual uniformity.
+Display P3 input is auto-detected. When `colorSpace == .oklch`, sampled pixels
+use the matching sRGB-to-OKLCH or Display P3-to-OKLCH conversion before
+quantization. Returned `PaletteColor` values are untagged 8-bit RGB, and the
+default path converts them back to sRGB. `colorSpaceUsed` can still record a P3
+input; it is not an embedded output profile. The built-in SwiftUI/UIKit
+adapters emit sRGB. See <doc:ColorSpaces> for the exact pipeline and output
+boundary.
 
 ### Choosing an `ImageSource`
 
 `ImageSource` controls where pixels come from. The right case depends on
 where the bytes already live:
 
-- `.data(_)` — bytes you already hold in memory or fetched over the
-  network. **Most-optimized path** for HEIC/JPEG: PaletteKit constructs
-  the `CGImageSource` directly from `Data`, skipping any file-system
-  hop. Measured ~17% faster than `.url(_)` on iPhone 15 Pro for a 4MP
-  HEIC input.
-- `.url(_)` — file on disk. The decoder can mmap the file directly,
-  which is the right call when the bytes are already on disk.
+- `.data(_)` — bytes you already hold in memory or fetched over the network.
+  PaletteKit constructs the `CGImageSource` directly from `Data`, skipping a
+  file-system hop.
+- `.url(_)` — file on disk. ImageIO reads from the file URL without requiring
+  the caller to create a `Data` value first.
 - `.cgImage(_)` — you've already decoded a `CGImage` somewhere else
   (e.g. AppKit/UIKit gave you one). PaletteKit re-uses it as-is.
 
@@ -70,32 +75,36 @@ If you're holding `Data` and have a choice, prefer `.data(_)`.
 
 ### Choosing accuracy vs speed
 
-There are four common goals; pick the row that matches yours.
+There are three common goals; pick the row that matches yours.
 
-| You want… | `quantizer` | `downsample` | Notes |
-| --- | --- | --- | --- |
-| **A palette, no fuss** | `.auto` | default | The default. Always CPU. |
-| **Maximum color accuracy** | `.cpu` | `.disabled` | Process every pixel. Slowest, most accurate. |
-| **Accuracy + speed on large inputs** | `.metal` | `.disabled` | ≥4MP only. ~5-10% quantize win vs CPU raw. |
-| **Ensure work runs on GPU** | `.metal` | default | Falls back to CPU if Metal is unavailable. |
+| You want… | `quality` | `quantizer` | `downsample` | Notes |
+| --- | --- | --- | --- | --- |
+| **A palette with defaults** | default | `.auto` | default | Samples every tenth pixel; uses CPU. |
+| **Sample every source pixel** | `.highest` | `.cpu` | `.disabled` | Highest input detail and the most CPU work. |
+| **Compare Metal on a large input** | `.highest` | `.metal` | `.disabled` | Measure against CPU with `collectTimings`. |
 
 ```swift
-// Default — CPU MMCQ with auto-downsample to ~1M pixels:
+// Default — CPU MMCQ with up to about 1M raster pixels:
 ExtractionOptions()                                    // == .auto, default downsample
 
-// Maximum accuracy — every pixel, CPU MMCQ:
-ExtractionOptions(downsample: .disabled, quantizer: .cpu)
+// Every source pixel, CPU MMCQ:
+ExtractionOptions(quality: .highest, downsample: .disabled, quantizer: .cpu)
 
-// Large-input accuracy + Metal (≥4MP raw):
-ExtractionOptions(downsample: .disabled, quantizer: .metal)
+// The same full-sampling workload with a Metal histogram:
+ExtractionOptions(quality: .highest, downsample: .disabled, quantizer: .metal)
 
 // Custom quantizer:
 ExtractionOptions(quantizer: .custom(MyQuantizer()))
 ```
 
-`.auto` always picks CPU regardless of image size — on-device
-measurements showed Metal didn't beat CPU at default settings. See
-<doc:PerformanceTuning> for the underlying numbers.
+`.auto` always picks CPU regardless of image size. Use `collectTimings` to
+compare CPU and Metal with the images and options your application uses. See
+<doc:PerformanceTuning> for the measurement workflow.
+
+On targets where the Metal framework cannot be imported, an explicit `.metal`
+selection uses the CPU implementation. On Metal-capable targets, failure to
+create a device, command queue, shader library, or compute pipeline is surfaced
+as an error.
 
 ### SwiftUI integration
 
@@ -103,8 +112,11 @@ measurements showed Metal didn't beat CPU at default settings. See
 with any `ShapeStyle`-accepting modifier without an adapter call:
 
 ```swift
-let palette = try await extractor.palette(from: .data(imageData))
-let swatches = try await extractor.swatches(from: .data(imageData))
+let palette = try await extractor.palette(
+    from: .data(imageData),
+    options: ExtractionOptions(colorCount: 16)
+)
+let swatches = SwatchClassifier().classify(palette: palette)
 
 Rectangle()
     .fill(palette.dominant ?? .black)

--- a/PaletteKit.docc/Tutorials/PerformanceTuning.md
+++ b/PaletteKit.docc/Tutorials/PerformanceTuning.md
@@ -5,9 +5,12 @@ places: decoding pixels and building the MMCQ histogram.
 
 ## Decoding
 
-The loader prefers `CGImageSourceCreateThumbnailAtIndex` with
-`kCGImageSourceThumbnailMaxPixelSize`, so a 12-megapixel photo never
-allocates a 48-MB RGBA buffer. Adjust the cap with `downsample`:
+For `Data` and URL sources, the loader first requests an ImageIO thumbnail with
+`CGImageSourceCreateThumbnailAtIndex` and
+`kCGImageSourceThumbnailMaxPixelSize`. This avoids a full-resolution decode
+when thumbnail creation succeeds. ImageIO can fall back to a full decode, and
+a `CGImage` source is already decoded before PaletteKit receives it. Adjust the
+target with `downsample`:
 
 ```swift
 ExtractionOptions(downsample: .maxEdge(1024))
@@ -24,27 +27,36 @@ embarrassingly parallel; the median-cut phase is not.
   then hands the result to the same median-cut engine.
 
 The Metal path pays a small cold-start cost the first time
-``MetalContext`` is warmed up (shader compile + pipeline build). After
-that, subsequent extractions are fast. The first extraction reaches steady
-state after ``MetalMmcqQuantizer/prepare()`` has run once per process.
+`MetalContext` is warmed up (shader compile + pipeline build). After
+that, subsequent extractions reuse the cached resources.
 
 ## Auto-selection
 
-``QuantizerSelection/auto`` **always selects CPU MMCQ.** On-device
-measurements (iPhone 15 Pro / A17 Pro, 4096² photos) showed CPU and
-Metal within ≤4ms after auto-downsample, so size-based routing added
-complexity without measurable wins at default settings.
+``QuantizerSelection/auto`` **always selects CPU MMCQ.** This keeps the default
+path predictable and avoids paying Metal setup and transfer costs without a
+workload-specific measurement.
 
-Metal becomes useful in a narrow band — **raw mode + ≥4MP input** —
-where it shaves ~5-10% off quantize. See <doc:Options> for the full
-"Choosing accuracy vs speed" decision tree, or jump straight to the
-overrides:
+Metal is available for large, non-downsampled inputs. Whether it helps depends
+on the device, source image, sampling options, and call frequency. See
+<doc:Options> for the full "Choosing accuracy vs speed" decision tree, or
+compare the explicit overrides with `collectTimings`.
 
 ```swift
-ExtractionOptions(quantizer: .cpu)    // explicit CPU
-ExtractionOptions(quantizer: .metal)  // explicit Metal (degrades to CPU
-                                      // if Metal is unavailable)
+let cpu = ExtractionOptions(
+    quality: .highest,
+    downsample: .disabled,
+    quantizer: .cpu
+)
+let metal = ExtractionOptions(
+    quality: .highest,
+    downsample: .disabled,
+    quantizer: .metal
+)
 ```
+
+On a Metal-capable target, device, shader, or pipeline creation failures are
+reported as extraction errors. Measure the path with your own representative
+images before enabling it in production.
 
 In `DEBUG` builds, PaletteKit emits a console hint when `.metal` is
 selected on input that's too small to benefit (sampled pixel count
@@ -54,8 +66,8 @@ selected on input that's too small to benefit (sampled pixel count
 
 PaletteKit emits `os_signpost` events on
 `com.paletteKit / pointsOfInterest`. Record an Instruments trace with the
-"Points of Interest" template to see decode / sample / quantize durations
-around any call.
+"Points of Interest" template to see the overall `extract` interval around a
+call. Use `collectTimings` for separate decode, sample, and quantize durations.
 
 ## Measuring your own workloads
 

--- a/Sources/PaletteKit/API/PaletteExtractor.swift
+++ b/Sources/PaletteKit/API/PaletteExtractor.swift
@@ -132,9 +132,10 @@ public struct PaletteExtractor: Sendable {
 
     /// Convenience: returns the single most representative color.
     ///
-    /// Runs a 5-color extraction internally and returns the color with the
-    /// highest population. Use ``palette(from:options:)`` instead when you need
-    /// the full result.
+    /// Runs palette extraction with the supplied options and returns the color
+    /// with the highest population. A `colorCount` below the valid palette
+    /// range is normalized to 5 for this convenience method. Use
+    /// ``palette(from:options:)`` when you need the full result.
     public func dominantColor(
         from source: ImageSource,
         options: ExtractionOptions = .init()

--- a/Sources/PaletteKit/Graphic/Async/AsyncPaletteGraphic.swift
+++ b/Sources/PaletteKit/Graphic/Async/AsyncPaletteGraphic.swift
@@ -115,7 +115,7 @@ public struct AsyncPaletteGraphic<Content: View>: View {
 
 extension AsyncPaletteGraphic where Content == AnyView {
     /// Convenience init that auto-renders ``PaletteGraphic`` on success
-    /// and shows ``placeholder`` during loading and on failure. Use the
+    /// and shows `placeholder` during loading and on failure. Use the
     /// phase-based init when you need to observe phases or compose
     /// secondary UI alongside the resolved graphic.
     ///

--- a/Sources/PaletteKit/Graphic/Async/AsyncPaletteGraphicTransition.swift
+++ b/Sources/PaletteKit/Graphic/Async/AsyncPaletteGraphicTransition.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Cross-fade transition applied when ``AsyncPaletteGraphic`` resolves
 /// asynchronously (cache miss). Cache hits skip the transition.
 ///
-/// Set on a SwiftUI subtree via ``SwiftUI/View/asyncPaletteGraphicTransition(_:)``.
+/// Set on a SwiftUI subtree via `View.asyncPaletteGraphicTransition(_:)`.
 /// UIKit consumers configure ``AsyncPaletteGraphicView/transition`` directly.
 public struct AsyncPaletteGraphicTransition: Equatable, Sendable {
     public let animation: Animation

--- a/Sources/PaletteKit/Graphic/PaletteGraphic.swift
+++ b/Sources/PaletteKit/Graphic/PaletteGraphic.swift
@@ -91,7 +91,7 @@ extension PaletteGraphic {
         public var direction: GradientDirection
         /// Start anchor for the linear gradient flow. Ignored when
         /// ``direction`` is `.radial`. Uses SwiftUI's standard
-        /// ``SwiftUI/UnitPoint`` (origin top-leading, y down).
+        /// `SwiftUI.UnitPoint` (origin top-leading, y down).
         public var linearStart: UnitPoint
         /// End anchor for the linear gradient flow. Ignored when
         /// ``direction`` is `.radial`.

--- a/Sources/PaletteKit/Loaders/ImageSource.swift
+++ b/Sources/PaletteKit/Loaders/ImageSource.swift
@@ -1,9 +1,20 @@
 import CoreGraphics
 import Foundation
 
+/// The image input consumed by ``PaletteExtractor``.
+///
+/// Use ``cgImage(_:)`` for an image that is already decoded, ``data(_:)`` for
+/// encoded bytes, and ``url(_:)`` for an image file on disk. PaletteKit does
+/// not perform HTTP networking; download a remote image with your networking
+/// layer and pass the resulting `Data`.
 public enum ImageSource: Sendable {
+    /// An image that is already decoded as a Core Graphics image.
     case cgImage(CGImage)
+
+    /// Encoded image bytes that ImageIO can decode.
     case data(Data)
+
+    /// The URL of an image file that ImageIO can read.
     case url(URL)
 }
 

--- a/Sources/PaletteKit/Model/Options.swift
+++ b/Sources/PaletteKit/Model/Options.swift
@@ -1,8 +1,19 @@
 import Foundation
 
+/// A source color space or an extraction color-space mode.
+///
+/// ``oklch`` is the recommended extraction mode. ``sRGB`` and ``displayP3``
+/// quantize rasterized RGB channel values directly; selecting either mode does
+/// not convert pixels from the other RGB color space.
 public enum ColorSpace: Sendable, Equatable {
+    /// The sRGB color space, or direct RGB-space quantization labeled as sRGB.
     case sRGB
+
+    /// The Display P3 color space, or direct RGB-space quantization labeled as
+    /// Display P3.
     case displayP3
+
+    /// Source-aware OKLCH quantization that returns clamped, 8-bit sRGB colors.
     case oklch
 }
 

--- a/Sources/PaletteKit/Model/PaletteColor+UIKit.swift
+++ b/Sources/PaletteKit/Model/PaletteColor+UIKit.swift
@@ -18,7 +18,7 @@ extension UIColor {
 extension PaletteColor {
     /// A Core Graphics representation of this color tagged sRGB. Use directly
     /// with `CALayer.backgroundColor`, `CGContext` fills, etc., without an
-    /// intermediate ``UIColor`` round-trip.
+    /// intermediate `UIColor` round-trip.
     public var cgColor: CGColor {
         CGColor(
             srgbRed: CGFloat(rgb.r) / 255,


### PR DESCRIPTION
## What changed

- Add focused DocC guides for choosing an extraction result, image input workflows, Display P3 and OKLCH behavior, and common questions.
- Reorganize the DocC landing page and existing tutorials around developer tasks and search intent.
- Correct documentation for sRGB output boundaries, Metal selection, downsampling, remote image loading, result reuse, performance measurement, and accessibility validation.
- Expand public symbol documentation for extraction sources, color-space modes, and UI adapters.
- Leave `README.md` and runtime behavior unchanged.

## Why

PaletteKit already exposes the relevant APIs, but several implementation boundaries were either difficult to discover or described too broadly. The new structure gives developers direct, citable answers while keeping claims aligned with the implementation.

## Developer impact

Documentation-only and public documentation-comment changes. No runtime API or behavior changes.

## Validation

- DocC conversion with `--warnings-as-errors`
- `PaletteExtractorTests`: 8/8 passed
- `git diff --check`
