### PR TITLE
ci: stabilize and scope pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,27 +111,100 @@ jobs:
           sudo xcode-select -s "$XCODE"
           xcodebuild -version
 
-      - name: Pick an iOS 26 iPhone simulator
+      - name: Pick and boot the latest iOS 26 iPhone simulator
         id: sim
         run: |
-          xcrun simctl list runtimes | grep iOS || true
-          UDID=$(xcrun simctl list devices available --json \
-            | jq -r '.devices | to_entries
-                      | map(select(.key | test("iOS-26")))
-                      | (.[0].value // [])
-                      | map(select(.name | startswith("iPhone")))
-                      | (.[0].udid // empty)')
+          RUNTIME_ID=$(xcrun simctl list runtimes available --json \
+            | jq -r '[.runtimes[]
+                      | select(.platform == "iOS")
+                      | select(.version | startswith("26."))
+                      | {identifier, parts: (.version | split(".") | map(tonumber))}]
+                     | sort_by(.parts)
+                     | last
+                     | .identifier // empty')
+          if [ -z "$RUNTIME_ID" ]; then
+            echo "No available iOS 26 runtime found:"
+            xcrun simctl list runtimes
+            exit 1
+          fi
+
+          DEVICE=$(xcrun simctl list devices available --json \
+            | jq -c --arg runtime "$RUNTIME_ID" '
+                (.devices[$runtime] // [])
+                | map(select(.isAvailable and (.name | startswith("iPhone"))))
+                | ((map(select(.name == "iPhone 17 Pro")) + .) | .[0] // empty)')
+          UDID=$(echo "$DEVICE" | jq -r '.udid // empty')
+          DEVICE_NAME=$(echo "$DEVICE" | jq -r '.name // empty')
           if [ -z "$UDID" ]; then
-            echo "No iOS 26 iPhone simulator available:"
+            echo "No iPhone simulator available for $RUNTIME_ID:"
             xcrun simctl list devices available
             exit 1
           fi
-          echo "Using simulator $UDID"
+
+          STATE=$(xcrun simctl list devices --json \
+            | jq -r --arg udid "$UDID" '
+                [.devices[][] | select(.udid == $udid) | .state][0] // empty')
+          if [ "$STATE" != "Booted" ]; then
+            xcrun simctl boot "$UDID"
+          fi
+          xcrun simctl bootstatus "$UDID" -b
+          xcrun simctl spawn "$UDID" launchctl print system > /dev/null
+
+          echo "Using $DEVICE_NAME ($UDID) on $RUNTIME_ID"
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 
-      - name: Test on iOS Simulator (core suite)
+      - name: Test async loader and view suites
+        timeout-minutes: 5
+        run: |
+          xcodebuild test \
+            -scheme PaletteKit-Package \
+            -only-testing:PaletteKitTests/AsyncTestSupportTests \
+            -only-testing:PaletteKitTests/AsyncPaletteGraphicLoaderTests \
+            -only-testing:PaletteKitTests/AsyncPaletteGraphicViewTests \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
+            -resultBundlePath "$RUNNER_TEMP/PaletteKitAsync.xcresult"
+
+      - name: Test remaining iOS core suite
+        timeout-minutes: 5
         run: |
           xcodebuild test \
             -scheme PaletteKit-Package \
             -only-testing:PaletteKitTests \
-            -destination "id=${{ steps.sim.outputs.udid }}"
+            -skip-testing:PaletteKitTests/AsyncTestSupportTests \
+            -skip-testing:PaletteKitTests/AsyncPaletteGraphicLoaderTests \
+            -skip-testing:PaletteKitTests/AsyncPaletteGraphicViewTests \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
+            -resultBundlePath "$RUNNER_TEMP/PaletteKitCore.xcresult"
+
+      - name: Collect simulator diagnostics
+        if: failure() || cancelled()
+        timeout-minutes: 2
+        env:
+          UDID: ${{ steps.sim.outputs.udid }}
+        run: |
+          DIAGNOSTICS="$RUNNER_TEMP/ios-diagnostics"
+          mkdir -p "$DIAGNOSTICS"
+          xcrun simctl list > "$DIAGNOSTICS/simctl-list.txt"
+          if [ -n "$UDID" ]; then
+            xcrun simctl spawn "$UDID" log show \
+              --style compact \
+              --last 20m \
+              > "$DIAGNOSTICS/device.log" 2>&1 || true
+            xcrun simctl diagnose \
+              -b \
+              --timeout=60 \
+              --output="$DIAGNOSTICS" \
+              --udid="$UDID" || true
+          fi
+
+      - name: Upload iOS test diagnostics
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-diagnostics
+          path: |
+            ${{ runner.temp }}/PaletteKitAsync.xcresult
+            ${{ runner.temp }}/PaletteKitCore.xcresult
+            ${{ runner.temp }}/ios-diagnostics
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,67 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.diff.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check code paths
+        id: diff
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
+          else
+            BASE_SHA="$PUSH_BASE_SHA"
+          fi
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "Base commit unavailable; running CI defensively."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet "$BASE_SHA" "$GITHUB_SHA" -- \
+            .github/workflows \
+            Examples \
+            Package.swift \
+            Package.resolved \
+            Sources \
+            Tests; then
+            echo "Only documentation or repository metadata changed; skipping build and test jobs."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Code, tests, package configuration, examples, or CI changed; running build and test jobs."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Build & Test (iOS 17+ / Swift 6)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-15
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select latest Xcode
         run: |
-          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -n 1)
+          XCODE=$(find /Applications -maxdepth 1 -name 'Xcode_*.app' -print \
+            | sort -V \
+            | tail -n 1)
           if [ -z "$XCODE" ]; then
             echo "No Xcode installation found. Available:"
-            ls /Applications | grep -i xcode || true
+            find /Applications -maxdepth 1 -iname '*xcode*' -print
             exit 1
           fi
           echo "Using $XCODE"
@@ -41,17 +90,21 @@ jobs:
 
   ios-test:
     name: iOS Simulator Tests
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: macos-15
-    if: github.event_name == 'pull_request'
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select latest Xcode
         run: |
-          XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -n 1)
+          XCODE=$(find /Applications -maxdepth 1 -name 'Xcode_*.app' -print \
+            | sort -V \
+            | tail -n 1)
           if [ -z "$XCODE" ]; then
             echo "No Xcode installation found. Available:"
-            ls /Applications | grep -i xcode || true
+            find /Applications -maxdepth 1 -iname '*xcode*' -print
             exit 1
           fi
           echo "Using $XCODE"

--- a/Tests/PaletteKitTests/AsyncPaletteGraphicLoaderTests.swift
+++ b/Tests/PaletteKitTests/AsyncPaletteGraphicLoaderTests.swift
@@ -6,6 +6,11 @@ import Foundation
 @MainActor
 @Suite("AsyncPaletteGraphicLoader")
 struct AsyncPaletteGraphicLoaderTests {
+    private enum LoadEvent: Sendable {
+        case success(fromCache: Bool)
+        case failure
+    }
+
     @Test("initial phase is .empty")
     func initialPhase() {
         let loader = AsyncPaletteGraphicLoader()
@@ -49,6 +54,15 @@ struct AsyncPaletteGraphicLoaderTests {
         )
 
         let loader = AsyncPaletteGraphicLoader()
+        let (events, eventContinuation) = AsyncStream<LoadEvent>.makeStream()
+        loader.onSuccess = { _, _, fromCache in
+            eventContinuation.yield(.success(fromCache: fromCache))
+            eventContinuation.finish()
+        }
+        loader.onFailure = { _ in
+            eventContinuation.yield(.failure)
+            eventContinuation.finish()
+        }
         loader.load(context: context, cache: cache)
 
         // Should transition to .loading immediately.
@@ -56,8 +70,15 @@ struct AsyncPaletteGraphicLoaderTests {
             Issue.record("expected .loading after kick-off, got \(loader.phase)")
         }
 
-        // Wait for completion (poll with small sleeps; integration boundary).
-        try await waitForSuccess(loader: loader, timeout: .seconds(30))
+        let event = try await AsyncTestSupport.nextEvent(
+            from: events,
+            waitingFor: "the cache-miss load callback"
+        )
+        guard case .success(let callbackFromCache) = event else {
+            Issue.record("expected the success callback, got failure")
+            return
+        }
+        #expect(callbackFromCache == false)
 
         guard case .success(let p, _, let fromCache) = loader.phase else {
             Issue.record("expected .success, got \(loader.phase)")
@@ -74,7 +95,16 @@ struct AsyncPaletteGraphicLoaderTests {
     func failurePath() async throws {
         let loader = AsyncPaletteGraphicLoader()
         var captured: Error?
-        loader.onFailure = { captured = $0 }
+        let (events, eventContinuation) = AsyncStream<LoadEvent>.makeStream()
+        loader.onSuccess = { _, _, fromCache in
+            eventContinuation.yield(.success(fromCache: fromCache))
+            eventContinuation.finish()
+        }
+        loader.onFailure = {
+            captured = $0
+            eventContinuation.yield(.failure)
+            eventContinuation.finish()
+        }
 
         // 1×1 white CGImage with `.fail` fallback strategy → all pixels
         // filtered (default `ignoreWhite = true` drops the only pixel) →
@@ -87,7 +117,14 @@ struct AsyncPaletteGraphicLoaderTests {
         )
         loader.load(context: context, cache: nil)
 
-        try await waitForFailure(loader: loader, timeout: .seconds(30))
+        let event = try await AsyncTestSupport.nextEvent(
+            from: events,
+            waitingFor: "the invalid-source failure callback"
+        )
+        guard case .failure = event else {
+            Issue.record("expected the failure callback, got success")
+            return
+        }
 
         if case .failure = loader.phase { } else {
             Issue.record("expected .failure, got \(loader.phase)")
@@ -159,38 +196,6 @@ struct AsyncPaletteGraphicLoaderTests {
         let a = ResolutionContext(image: .url(url), options: optsA, cacheKey: nil)
         let b = ResolutionContext(image: .url(url), options: optsB, cacheKey: nil)
         #expect(a.storageKey != b.storageKey)
-    }
-
-    // MARK: - Helpers
-
-    @MainActor
-    private func waitForSuccess(loader: AsyncPaletteGraphicLoader,
-                                timeout: Duration) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while ContinuousClock.now < deadline {
-            if case .success = loader.phase { return }
-            if case .failure(let e) = loader.phase {
-                Issue.record("expected .success, got .failure(\(e))")
-                return
-            }
-            try await Task.sleep(for: .milliseconds(50))
-        }
-        Issue.record("timed out waiting for .success; final phase: \(loader.phase)")
-    }
-
-    @MainActor
-    private func waitForFailure(loader: AsyncPaletteGraphicLoader,
-                                timeout: Duration) async throws {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while ContinuousClock.now < deadline {
-            if case .failure = loader.phase { return }
-            if case .success = loader.phase {
-                Issue.record("expected .failure, got .success")
-                return
-            }
-            try await Task.sleep(for: .milliseconds(50))
-        }
-        Issue.record("timed out waiting for .failure; final phase: \(loader.phase)")
     }
 }
 

--- a/Tests/PaletteKitTests/AsyncPaletteGraphicViewTests.swift
+++ b/Tests/PaletteKitTests/AsyncPaletteGraphicViewTests.swift
@@ -18,23 +18,33 @@ struct AsyncPaletteGraphicViewTests {
         let cgImage = AsyncTestSupport.makeSolidImage(rgb: (200, 50, 50))
 
         var resolveCount = 0
-        view.onSuccess = { _, _ in resolveCount += 1 }
+        let (firstEvents, firstEventContinuation) = AsyncStream<Void>.makeStream()
+        view.onSuccess = { _, _ in
+            resolveCount += 1
+            firstEventContinuation.yield()
+            firstEventContinuation.finish()
+        }
         view.cacheKey = AnyHashable("reload-force-test")
         view.imageSource = .cgImage(cgImage)
 
-        // Wait for first resolution.
-        let deadline1 = ContinuousClock.now.advanced(by: .seconds(5))
-        while ContinuousClock.now < deadline1, resolveCount < 1 {
-            try await Task.sleep(for: .milliseconds(50))
-        }
+        try await AsyncTestSupport.nextEvent(
+            from: firstEvents,
+            waitingFor: "the initial view load callback"
+        )
         #expect(resolveCount == 1)
 
         // Force reload — must trigger a second resolution.
-        view.reload()
-        let deadline2 = ContinuousClock.now.advanced(by: .seconds(5))
-        while ContinuousClock.now < deadline2, resolveCount < 2 {
-            try await Task.sleep(for: .milliseconds(50))
+        let (reloadEvents, reloadEventContinuation) = AsyncStream<Void>.makeStream()
+        view.onSuccess = { _, _ in
+            resolveCount += 1
+            reloadEventContinuation.yield()
+            reloadEventContinuation.finish()
         }
+        view.reload()
+        try await AsyncTestSupport.nextEvent(
+            from: reloadEvents,
+            waitingFor: "the forced reload callback"
+        )
         #expect(resolveCount == 2)
     }
 
@@ -43,16 +53,18 @@ struct AsyncPaletteGraphicViewTests {
         let view = AsyncPaletteGraphicView(frame: .init(x: 0, y: 0, width: 100, height: 100))
         let cgImage = AsyncTestSupport.makeSolidImage(rgb: (200, 50, 50))
 
-        var resolved = false
-        view.onSuccess = { _, _ in resolved = true }
+        let (events, eventContinuation) = AsyncStream<Void>.makeStream()
+        view.onSuccess = { _, _ in
+            eventContinuation.yield()
+            eventContinuation.finish()
+        }
         view.cacheKey = AnyHashable("success-test")
         view.imageSource = .cgImage(cgImage)
 
-        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
-        while ContinuousClock.now < deadline, !resolved {
-            try await Task.sleep(for: .milliseconds(50))
-        }
-        #expect(resolved == true)
+        try await AsyncTestSupport.nextEvent(
+            from: events,
+            waitingFor: "the view success callback"
+        )
     }
 
     @Test("cancel stops in-flight extraction")

--- a/Tests/PaletteKitTests/AsyncTestSupport.swift
+++ b/Tests/PaletteKitTests/AsyncTestSupport.swift
@@ -4,6 +4,48 @@ import Foundation
 @testable import PaletteKit
 
 enum AsyncTestSupport {
+    private enum EventWaitError: Error, CustomStringConvertible, Sendable {
+        case streamFinished(String)
+        case timedOut(String, Duration)
+
+        var description: String {
+            switch self {
+            case .streamFinished(let event):
+                return "event stream finished before \(event)"
+            case .timedOut(let event, let timeout):
+                return "timed out after \(timeout) waiting for \(event)"
+            }
+        }
+    }
+
+    /// Await a callback-backed event without repeatedly waking the main actor.
+    /// The timeout races the event itself, so an event delivered at the deadline
+    /// cannot be discarded by a separate wall-clock check.
+    static func nextEvent<Event: Sendable>(
+        from stream: AsyncStream<Event>,
+        timeout: Duration = .seconds(30),
+        waitingFor eventDescription: String
+    ) async throws -> Event {
+        try await withThrowingTaskGroup(of: Event.self) { group in
+            group.addTask {
+                for await event in stream {
+                    return event
+                }
+                throw EventWaitError.streamFinished(eventDescription)
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw EventWaitError.timedOut(eventDescription, timeout)
+            }
+
+            defer { group.cancelAll() }
+            guard let event = try await group.next() else {
+                throw EventWaitError.streamFinished(eventDescription)
+            }
+            return event
+        }
+    }
+
     /// Synthesise a small solid-color CGImage for in-memory tests
     /// (no disk / network roundtrip required).
     static func makeSolidImage(rgb: (UInt8, UInt8, UInt8), size: Int = 32) -> CGImage {

--- a/Tests/PaletteKitTests/AsyncTestSupportTests.swift
+++ b/Tests/PaletteKitTests/AsyncTestSupportTests.swift
@@ -1,0 +1,40 @@
+#if canImport(UIKit)
+import Foundation
+import Testing
+
+@Suite("Async test event waiting")
+struct AsyncTestSupportTests {
+    @Test("returns a callback event without polling")
+    func returnsEvent() async throws {
+        let (events, continuation) = AsyncStream<Int>.makeStream()
+        continuation.yield(42)
+        continuation.finish()
+
+        let event = try await AsyncTestSupport.nextEvent(
+            from: events,
+            timeout: .seconds(1),
+            waitingFor: "a test event"
+        )
+
+        #expect(event == 42)
+    }
+
+    @Test("timeout cancels the pending event wait")
+    func timesOut() async {
+        let (events, continuation) = AsyncStream<Void>.makeStream()
+        defer { continuation.finish() }
+
+        do {
+            try await AsyncTestSupport.nextEvent(
+                from: events,
+                timeout: .milliseconds(10),
+                waitingFor: "an event that is never sent"
+            )
+            Issue.record("expected the event wait to time out")
+        } catch {
+            // The timeout is the expected result. Reaching this catch also
+            // proves cancellation released the pending AsyncStream iterator.
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Replace polling-based asynchronous UI tests with callback-backed event waits.
- Skip the macOS and iOS test jobs for documentation-only or repository-metadata-only changes while still reporting required checks.
- Bound CI jobs with explicit timeouts, update `actions/checkout` to v6, and make Xcode discovery `actionlint`-clean.

## Background

The loader tests polled `phase` every 50 milliseconds until a wall-clock deadline. If the loader completed during the final sleep, the loop could cross the deadline and record a timeout without observing the completed state. The failing CI log demonstrated this mismatch: the timeout was recorded while the final phase was already the expected `.success` or `.failure` value. Repeated polling from `@MainActor` tests also introduced unnecessary executor wake-ups.

Separately, the workflow ran both macOS and iOS jobs for documentation-only pull requests and had no explicit job timeouts. One iOS Simulator run remained in `xcodebuild test` for more than 20 minutes. GitHub's default job timeout would otherwise allow a stuck runner to remain active for up to six hours.

## Solution

- Add a reusable test helper that races a callback-backed `AsyncStream` event against an explicit timeout, suspending instead of polling the main actor.
- Update loader and UIKit view tests to wait for the actual success or failure callback, then verify the resulting state and callback metadata.
- Cover both event delivery and timeout cancellation in dedicated helper tests.
- Add a lightweight `Detect code changes` job. The macOS and iOS jobs run only when `Sources`, `Tests`, `Examples`, package configuration, or CI workflows change.
- Use job-level conditions instead of workflow-level path filters so documentation-only pull requests still report successful skipped checks and remain compatible with required branch-protection checks.
- Limit the macOS job to 10 minutes and the iOS job to 15 minutes.
- Update `actions/checkout` from v4 to v6 and replace the warning-prone `ls | grep` Xcode discovery with `find`.

## Related Issue

None. This is CI reliability and maintenance work discovered while validating pull request #19.

## Verification

- Tests added or updated:
  - Added event-delivery and timeout-cancellation coverage for the asynchronous test helper.
  - Updated loader success and failure tests to verify callback type, callback metadata, final phase, and cache behavior without polling.
  - Updated UIKit view success and forced-reload tests to wait for callback events without polling.
  - Verified documentation-only changes are classified to skip expensive jobs and code changes are classified to run them.
- Commands run:
  - `actionlint .github/workflows/ci.yml`
  - `swift package resolve`
  - `swift build -c debug`
  - `swift test --filter PaletteKitTests --filter PaletteKitInsightsTests` — 55 tests, 0 failures.
  - Focused iOS asynchronous suites with `-test-iterations 20` — 320 test runs, 0 failures.
  - Full iOS core suite with `-test-iterations 10` — 1,410 test runs, 0 failures.
  - `git diff --check`
- Environment and platforms:
  - macOS 26.5.1, Xcode 26.4, Swift 6.3.
  - iPhone 17 Pro Simulator running iOS 26.4.
  - The workflow continues to target GitHub-hosted `macos-15` runners.

## Compatibility and Impact

- Public API: None.
- Behavioral impact: Package runtime behavior is unchanged. Only test synchronization and CI scheduling behavior change. Documentation-only changes now skip the expensive build and simulator jobs.
- Performance impact: No production performance impact. Asynchronous tests no longer wake the main actor every 50 milliseconds, and documentation-only pull requests no longer consume macOS runners.
- Affected platforms: GitHub Actions and iOS/UIKit test targets. Shipping library behavior on supported Apple platforms is unaffected.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Tests were added or updated where behavior changed, or I explained why they are not needed.
- [x] Regression tests cover the intended behavior or root cause rather than only a reported sample.
- [x] Public API changes are documented and reflected in the changelog, or this pull request has none.
- [x] I considered source compatibility, behavioral changes, and performance impact.
