### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to PaletteKit are documented here.
 
+## 2.1.1
+
+### Fixed
+- Prevented MMCQ crashes when distinct 8-bit colors collapse into a single
+  5-bit histogram cell, leaving no valid median-cut boundary (#15, #17).
+- Unsplittable boxes no longer block queue progress, and median cut can fall
+  back to another occupied axis while preserving positive-population boxes.
+
 ## 2.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ async-only Sendable API.
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/2dubu/PaletteKit", from: "2.1.0"),
+    .package(url: "https://github.com/2dubu/PaletteKit", from: "2.1.1"),
 ]
 ```
 

--- a/Sources/PaletteKit/PaletteKit.swift
+++ b/Sources/PaletteKit/PaletteKit.swift
@@ -1,4 +1,4 @@
 import Foundation
 
 /// The currently-shipped PaletteKit version string. Follows semver.
-public let paletteKitVersion = "2.1.0"
+public let paletteKitVersion = "2.1.1"


### PR DESCRIPTION
## Summary

- Bump `paletteKitVersion` from `2.1.0` to `2.1.1`.
- Recommend `2.1.1` as the minimum version in the README installation example.
- Document the MMCQ crash fixes included in the patch release.

## Background

This prepares the patch release following the MMCQ root-cause fix merged in #18. The version constant, installation documentation, changelog, and eventual Git tag should all describe the same release.

## Solution

Update the runtime version string and README dependency lower bound together, and add a focused `2.1.1` changelog entry for the fixes related to #15 and #17.

The `v2.1.1` tag should be created from `main` only after this pull request is merged.

## Related Issue

Relates to #15 and #17.

## Verification

- Tests added or updated: None; this changes release metadata and documentation only. The MMCQ regression tests were added in #18.
- Commands run:
  - `git diff --check`
  - `swift test --filter PaletteKitTests` — 50 tests in 11 suites passed.
- Environment and platforms: macOS 26.5.1, Xcode 26.4, Swift 6.3.

## Compatibility and Impact

- Public API: No signature changes; `paletteKitVersion` now reports `2.1.1`.
- Behavioral impact: New installations use the crash-fixed patch release as their minimum dependency.
- Performance impact: None.
- Affected platforms: All supported platforms, release metadata only.

## Checklist

- [x] This pull request is focused and contains no unrelated changes.
- [x] Tests were added or updated where behavior changed, or I explained why they are not needed.
- [x] Regression tests cover the intended behavior or root cause rather than only a reported sample.
- [x] Public API changes are documented and reflected in the changelog, or this pull request has none.
- [x] I considered source compatibility, behavioral changes, and performance impact.
